### PR TITLE
refactor switch layout test

### DIFF
--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -47,9 +47,9 @@ function innerBlocks() {
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/accordion', [
 		'Basic',
-		'Plain',
-		'Line Colored',
-		'Colored',
+		{ value: 'Plain', selector: '.ugb-accordion--design-plain' },
+		{ value: 'Line Colored', selector: '.ugb-accordion--design-line-colored' },
+		{ value: 'Colored', selector: '.ugb-accordion--design-colored' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/blockquote.spec.js
+++ b/cypress/integration/v2/blocks/blockquote.spec.js
@@ -25,11 +25,11 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/blockquote', [
-		'Basic',
-		'Plain',
-		'Centered Quote',
-		'Huge',
-		'Highlight',
+		{ value: 'Basic', selector: '.ugb-blockquote--design-basic' },
+		{ value: 'Plain', selector: '.ugb-blockquote--design-plain' },
+		{ value: 'Centered Quote', selector: '.ugb-blockquote--design-centered-quote' },
+		{ value: 'Huge', selector: '.ugb-blockquote--design-huge' },
+		{ value: 'Highlight', selector: '.ugb-blockquote--design-highlight' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/blog-posts.spec.js
+++ b/cypress/integration/v2/blocks/blog-posts.spec.js
@@ -22,18 +22,14 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/blog-posts', [
-		'Basic',
-		'List',
-		'Portfolio',
-		{
-			value: 'portfolio2',
-		},
-		'Vertical Card',
-		'Horizontal Card',
-		{
-			value: 'vertical-card2',
-		},
-		'Image Card',
+		{ value: 'Basic', selector: '.ugb-blog-posts--design-basic' },
+		{ value: 'List', selector: '.ugb-blog-posts--design-list' },
+		{ value: 'Portfolio', selector: '.ugb-blog-posts--design-portfolio' },
+		{ value: 'portfolio2', selector: '.ugb-blog-posts--design-portfolio2' },
+		{ value: 'Vertical Card', selector: '.ugb-blog-posts--design-vertical-card' },
+		{ value: 'Horizontal Card', selector: '.ugb-blog-posts--design-horizontal-card' },
+		{ value: 'vertical-card2', selector: '.ugb-blog-posts--design-vertical-card2' },
+		{ value: 'Image Card', selector: '.ugb-blog-posts--design-image-card' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/button.spec.js
+++ b/cypress/integration/v2/blocks/button.spec.js
@@ -23,12 +23,10 @@ function blockError() {
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/button', [
 		'Basic',
-		'Spread',
-		{
-			value: 'fullwidth',
-		},
-		'Grouped 1',
-		'Grouped 2',
+		{ value: 'Spread', selector: '.ugb-button--design-spread' },
+		{ value: 'fullwidth', selector: '.ugb-button--design-fullwidth' },
+		{ value: 'Grouped 1', selector: '.ugb-button--design-grouped-1' },
+		{ value: 'Grouped 2', selector: '.ugb-button--design-grouped-2' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/card.spec.js
+++ b/cypress/integration/v2/blocks/card.spec.js
@@ -22,11 +22,11 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/card', [
-		'Basic',
-		'Plain',
-		'Horizontal',
-		'Full',
-		'Faded',
+		{ value: 'Basic', selector: '.ugb-card--design-basic' },
+		{ value: 'Plain', selector: '.ugb-card--design-plain' },
+		{ value: 'Horizontal', selector: '.ugb-card--design-horizontal' },
+		{ value: 'Full', selector: '.ugb-card--design-full' },
+		{ value: 'Faded', selector: '.ugb-card--design-faded' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/columns.spec.js
+++ b/cypress/integration/v2/blocks/columns.spec.js
@@ -38,11 +38,11 @@ function innerBlocks() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/columns', [
-		'Grid',
-		'Plain',
-		'Uneven',
-		'Uneven 2',
-		'Tiled',
+		{ value: 'Grid', selector: '.ugb-columns--design-grid' },
+		{ value: 'Plain', selector: '.ugb-columns--design-plain' },
+		{ value: 'Uneven', selector: '.ugb-columns--design-uneven' },
+		{ value: 'Uneven 2', selector: '.ugb-columns--design-uneven-2' },
+		{ value: 'Tiled', selector: '.ugb-columns--design-tiled' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/container.spec.js
+++ b/cypress/integration/v2/blocks/container.spec.js
@@ -35,15 +35,11 @@ function innerBlocks() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/container', [
-		'Basic',
-		'Plain',
-		'Image',
-		{
-			value: 'image2',
-		},
-		{
-			value: 'image3',
-		},
+		{ value: 'Basic', selector: '.ugb-container--design-basic' },
+		{ value: 'Plain', selector: '.ugb-container--design-plain' },
+		{ value: 'Image', selector: '.ugb-container--design-image' },
+		{ value: 'image2', selector: '.ugb-container--design-image2' },
+		{ value: 'image3', selector: '.ugb-container--design-image3' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/count-up.spec.js
+++ b/cypress/integration/v2/blocks/count-up.spec.js
@@ -23,10 +23,10 @@ function blockError() {
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/count-up', [
 		'Plain',
-		'Plain 2',
-		'Side',
-		'Abstract',
-		'Boxed',
+		{ value: 'Plain 2', selector: '.ugb-countup--design-plain-2' },
+		{ value: 'Side', selector: '.ugb-countup--design-side' },
+		{ value: 'Abstract', selector: '.ugb-countup--design-abstract' },
+		{ value: 'Boxed', selector: '.ugb-countup--design-boxed' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/cta.spec.js
+++ b/cypress/integration/v2/blocks/cta.spec.js
@@ -23,11 +23,11 @@ function blockError() {
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/cta', [
 		'Basic',
-		'Plain',
-		'Horizontal',
-		'Horizontal 2',
-		'Horizontal 3',
-		'Split Centered',
+		{ value: 'Plain', selector: '.ugb-cta--design-plain' },
+		{ value: 'Horizontal', selector: '.ugb-cta--design-horizontal' },
+		{ value: 'Horizontal 2', selector: '.ugb-cta--design-horizontal-2' },
+		{ value: 'Horizontal 3', selector: '.ugb-cta--design-horizontal-3' },
+		{ value: 'Split Centered', selector: '.ugb-cta--design-split-centered' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/divider.spec.js
+++ b/cypress/integration/v2/blocks/divider.spec.js
@@ -24,10 +24,10 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/divider', [
-		'Basic',
-		'Bar',
-		'Dots',
-		'Asterisks',
+		{ value: 'Basic', selector: '.ugb-divider--design-basic' },
+		{ value: 'Bar', selector: '.ugb-divider--design-bar' },
+		{ value: 'Dots', selector: '.ugb-divider--design-dots' },
+		{ value: 'Asterisks', selector: '.ugb-divider--design-asterisks' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -12,11 +12,11 @@ describe( 'Feature Grid Block', () => {
 	it( 'should not trigger block error when refreshing the page', blockErrorTest( 'ugb/feature-grid' ) )
 
 	it( 'should switch layout', switchLayouts( 'ugb/feature-grid', [
-		'Basic',
-		'Plain',
-		'Horizontal',
-		'Large Mid',
-		'Zigzag',
+		{ value: 'Basic', selector: '.ugb-feature-grid--design-basic' },
+		{ value: 'Plain', selector: '.ugb-feature-grid--design-plain' },
+		{ value: 'Horizontal', selector: '.ugb-feature-grid--design-horizontal' },
+		{ value: 'Large Mid', selector: '.ugb-feature-grid--design-large-mid' },
+		{ value: 'Zigzag', selector: '.ugb-feature-grid--design-zigzag' },
 	] ) )
 
 	it( 'should switch design', switchDesigns( 'ugb/feature-grid', [

--- a/cypress/integration/v2/blocks/feature.spec.js
+++ b/cypress/integration/v2/blocks/feature.spec.js
@@ -22,37 +22,51 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/feature', [
-		'Basic',
-		'Plain',
+		{ value: 'Basic', selector: '.ugb-feature--design-basic' },
+		{ value: 'Plain', selector: '.ugb-feature--design-plain' },
 		{
 			value: 'half',
+			selector: '.ugb-feature--design-half',
 		},
 		{
 			value: 'overlap',
+			selector: '.ugb-feature--design-overlap',
 		},
 		{
 			value: 'overlap2',
+			selector: '.ugb-feature--design-overlap2',
 		},
 		{
 			value: 'overlap3',
+			selector: '.ugb-feature--design-overlap3',
 		},
 		{
 			value: 'overlap4',
+			selector: '.ugb-feature--design-overlap4',
 		},
 		{
 			value: 'overlap5',
+			selector: '.ugb-feature--design-overlap5',
 		},
 		{
 			value: 'overlap-bg',
+			selector: '.ugb-feature--design-overlap-bg',
 		},
 		{
 			value: 'overlap-bg2',
+			selector: '.ugb-feature--design-overlap-bg2',
 		},
 		{
 			value: 'overlap-bg3',
+			selector: '.ugb-feature--design-overlap-bg3',
 		},
 		{
 			value: 'overlap-bg4',
+			selector: '.ugb-feature--design-overlap-bg4',
+		},
+		{
+			value: 'overlap-bg5',
+			selector: '.ugb-feature--design-overlap-bg5',
 		},
 	] ) )
 }

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -25,13 +25,13 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/header', [
-		'Basic',
-		'Plain',
-		'Half Overlay',
-		'Center Overlay',
-		'Side Overlay',
-		'Half',
-		'Huge',
+		{ value: 'Basic', selector: '.ugb-header--design-basic' },
+		{ value: 'Plain', selector: '.ugb-header--design-plain' },
+		{ value: 'Half Overlay', selector: '.ugb-header--design-half-overlay' },
+		{ value: 'Center Overlay', selector: '.ugb-header--design-center-overlay' },
+		{ value: 'Side Overlay', selector: '.ugb-header--design-side-overlay' },
+		{ value: 'Half', selector: '.ugb-header--design-half' },
+		{ value: 'Huge', selector: '.ugb-header--design-huge' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/image-box.spec.js
+++ b/cypress/integration/v2/blocks/image-box.spec.js
@@ -22,12 +22,12 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/image-box', [
-		'Basic',
-		'Plain',
-		'Box',
-		'Captioned',
-		'Fade',
-		'Line',
+		{ value: 'Basic', selector: '.ugb-image-box--design-basic' },
+		{ value: 'Plain', selector: '.ugb-image-box--design-plain' },
+		{ value: 'Box', selector: '.ugb-image-box--design-box' },
+		{ value: 'Captioned', selector: '.ugb-image-box--design-captioned' },
+		{ value: 'Fade', selector: '.ugb-image-box--design-fade' },
+		{ value: 'Line', selector: '.ugb-image-box--design-line' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/notification.spec.js
+++ b/cypress/integration/v2/blocks/notification.spec.js
@@ -22,11 +22,11 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/notification', [
-		'Basic',
-		'Plain',
-		'Bordered',
-		'Outlined',
-		'Large Icon',
+		{ value: 'Basic', selector: '.ugb-notification--design-basic' },
+		{ value: 'Plain', selector: '.ugb-notification--design-plain' },
+		{ value: 'Bordered', selector: '.ugb-notification--design-bordered' },
+		{ value: 'Outlined', selector: '.ugb-notification--design-outlined' },
+		{ value: 'Large Icon', selector: '.ugb-notification--design-large-icon' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/number-box.spec.js
+++ b/cypress/integration/v2/blocks/number-box.spec.js
@@ -24,13 +24,11 @@ function blockError() {
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/number-box', [
 		'Basic',
-		'Plain',
-		'Background',
-		'Heading',
-		{
-			value: 'heading2',
-		},
-		'Faded',
+		{ value: 'Plain', selector: '.ugb-number-box--design-plain' },
+		{ value: 'Background', selector: '.ugb-number-box--design-background' },
+		{ value: 'Heading', selector: '.ugb-number-box--design-heading' },
+		{ value: 'heading2', selector: '.ugb-number-box--design-heading2' },
+		{ value: 'Faded', selector: '.ugb-number-box--design-faded' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/pricing-box.spec.js
+++ b/cypress/integration/v2/blocks/pricing-box.spec.js
@@ -22,11 +22,11 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/pricing-box', [
-		'Basic',
-		'Plain',
-		'Compact',
-		'Colored',
-		'Sectioned',
+		{ value: 'Basic', selector: '.ugb-pricing-box--design-basic' },
+		{ value: 'Plain', selector: '.ugb-pricing-box--design-plain' },
+		{ value: 'Compact', selector: '.ugb-pricing-box--design-compact' },
+		{ value: 'Colored', selector: '.ugb-pricing-box--design-colored' },
+		{ value: 'Sectioned', selector: '.ugb-pricing-box--design-sectioned' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/separator.spec.js
+++ b/cypress/integration/v2/blocks/separator.spec.js
@@ -24,18 +24,18 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/separator', [
-		'Wave 1',
-		'Wave 2',
-		'Wave 3',
-		'Wave 4',
-		'Slant 1',
-		'Slant 2',
-		'Curve 1',
-		'Curve 2',
-		'Curve 3',
-		'Rounded 1',
-		'Rounded 2',
-		'Rounded 3',
+		{ value: 'Wave 1', selector: '.ugb-separator--design-wave-1' },
+		{ value: 'Wave 2', selector: '.ugb-separator--design-wave-2' },
+		{ value: 'Wave 3', selector: '.ugb-separator--design-wave-3' },
+		{ value: 'Wave 4', selector: '.ugb-separator--design-wave-4' },
+		{ value: 'Slant 1', selector: '.ugb-separator--design-slant-1' },
+		{ value: 'Slant 2', selector: '.ugb-separator--design-slant-2' },
+		{ value: 'Curve 1', selector: '.ugb-separator--design-curve-1' },
+		{ value: 'Curve 2', selector: '.ugb-separator--design-curve-2' },
+		{ value: 'Curve 3', selector: '.ugb-separator--design-curve-3' },
+		{ value: 'Rounded 1', selector: '.ugb-separator--design-rounded-1' },
+		{ value: 'Rounded 2', selector: '.ugb-separator--design-rounded-2' },
+		{ value: 'Rounded 3', selector: '.ugb-separator--design-rounded-3' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/team-member.spec.js
+++ b/cypress/integration/v2/blocks/team-member.spec.js
@@ -22,12 +22,12 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/team-member', [
-		'Basic',
-		'Plain',
-		'Horizontal',
-		'Overlay',
-		'Overlay Simple',
-		'Half',
+		{ value: 'Basic', selector: '.ugb-team-member--design-basic' },
+		{ value: 'Plain', selector: '.ugb-team-member--design-plain' },
+		{ value: 'Horizontal', selector: '.ugb-team-member--design-horizontal' },
+		{ value: 'Overlay', selector: '.ugb-team-member--design-overlay' },
+		{ value: 'Overlay Simple', selector: '.ugb-team-member--design-overlay-simple' },
+		{ value: 'Half', selector: '.ugb-team-member--design-half' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/testimonial.spec.js
+++ b/cypress/integration/v2/blocks/testimonial.spec.js
@@ -22,15 +22,13 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/testimonial', [
-		'Basic',
-		'Plain',
-		{
-			value: 'basic2',
-		},
-		'Bubble',
-		'Background',
-		'Vertical',
-		'Vertical Inverse',
+		{ value: 'Basic', selector: '.ugb-testimonial--design-basic' },
+		{ value: 'Plain', selector: '.ugb-testimonial--design-plain' },
+		{ value: 'basic2', selector: '.ugb-testimonial--design-basic2' },
+		{ value: 'Bubble', selector: '.ugb-testimonial--design-bubble' },
+		{ value: 'Background', selector: '.ugb-testimonial--design-background' },
+		{ value: 'Vertical', selector: '.ugb-testimonial--design-vertical' },
+		{ value: 'Vertical Inverse', selector: '.ugb-testimonial--design-vertical-inverse' },
 	] ) )
 }
 

--- a/cypress/integration/v2/blocks/text.spec.js
+++ b/cypress/integration/v2/blocks/text.spec.js
@@ -25,9 +25,9 @@ function blockError() {
 
 function switchLayout() {
 	it( 'should switch layout', switchLayouts( 'ugb/text', [
-		'Plain',
-		'Side Title 1',
-		'Side Title 2',
+		{ value: 'Plain', selector: '.ugb-text--design-plain' },
+		{ value: 'Side Title 1', selector: '.ugb-text--design-side-title-1' },
+		{ value: 'Side Title 2', selector: '.ugb-text--design-side-title-2' },
 	] ) )
 }
 

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -23,6 +23,7 @@ Cypress.Commands.add( 'publish', publish )
 Cypress.Commands.add( 'changeIcon', changeIcon )
 Cypress.Commands.add( 'assertPluginError', assertPluginError )
 Cypress.Commands.add( 'appendBlock', appendBlock )
+Cypress.Commands.add( 'assertBlockError', assertBlockError )
 
 /**
  * Command for clicking the block inserter button
@@ -241,3 +242,9 @@ export function appendBlock( blockName = 'ugb/accordion', parentSelector ) {
 	cy.deleteBlock( blockName )
 }
 
+/**
+ * Command for asserting block error.
+ */
+export function assertBlockError() {
+	cy.get( '.block-editor-warning' ).should( 'not.exist' )
+}

--- a/cypress/support/commands/styles.js
+++ b/cypress/support/commands/styles.js
@@ -812,13 +812,17 @@ export function resetStyle( name, options = {} ) {
 /**
  * Command for changing the layout of the block.
  *
- * @param {string} option
+ * @param {string} value
  */
-export function adjustLayout( option = '' ) {
-	cy
-		.get( '.ugb-design-control-wrapper' )
-		.find( `input[value="${ typeof option === 'object' ? option.value : kebabCase( option ) }"]` )
-		.click( { force: true } )
+export function adjustLayout( value = '' ) {
+	const _char = ( value || '' ).charAt( 0 )
+	// If string value starts with a lowercase character, assign its value. Otherwise, force kebab casing.
+	if ( _char ) {
+		cy
+			.get( '.ugb-design-control-wrapper' )
+			.find( `input[value="${ _char === _char.toLowerCase() ? value : kebabCase( value ) }"]` )
+			.click( { force: true } )
+	}
 }
 
 /**

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -96,9 +96,9 @@ export const switchLayouts = ( blockName = 'ugb/accordion', layouts = [] ) => ()
 		if ( typeof layout === 'object' && ! Array.isArray( layout ) ) {
 			const { selector, value } = layout
 			cy.adjustLayout( value )
+			cy.publish()
 			if ( selector ) {
 				getAddresses( ( { currUrl, previewUrl } ) => {
-					cy.publish()
 					cy.get( selector ).should( 'exist' )
 					cy.visit( previewUrl )
 					cy.get( selector ).should( 'exist' )
@@ -106,7 +106,6 @@ export const switchLayouts = ( blockName = 'ugb/accordion', layouts = [] ) => ()
 					cy.assertBlockError()
 				} )
 			} else {
-				cy.publish()
 				cy.reload()
 				cy.assertBlockError()
 			}

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -70,6 +70,7 @@ export const switchDesigns = ( blockName = 'ugb/accordion', designs = [] ) => ()
 		cy.adjustDesign( design )
 		cy.publish()
 		cy.reload()
+		cy.assertBlockError()
 	} )
 	cy.publish()
 }
@@ -86,9 +87,30 @@ export const switchLayouts = ( blockName = 'ugb/accordion', layouts = [] ) => ()
 	cy.addBlock( blockName )
 	layouts.forEach( layout => {
 		cy.openInspector( blockName, 'Layout' )
-		cy.adjustLayout( layout )
-		cy.publish()
-		cy.reload()
+		if ( typeof layout === 'string' ) {
+			cy.adjustLayout( layout )
+			cy.publish()
+			cy.reload()
+			cy.assertBlockError()
+		}
+		if ( typeof layout === 'object' && ! Array.isArray( layout ) ) {
+			const { selector, value } = layout
+			cy.adjustLayout( value )
+			if ( selector ) {
+				getAddresses( ( { currUrl, previewUrl } ) => {
+					cy.publish()
+					cy.get( selector ).should( 'exist' )
+					cy.visit( previewUrl )
+					cy.get( selector ).should( 'exist' )
+					cy.visit( currUrl )
+					cy.assertBlockError()
+				} )
+			} else {
+				cy.publish()
+				cy.reload()
+				cy.assertBlockError()
+			}
+		}
 	} )
 	cy.publish()
 }


### PR DESCRIPTION
### Change switch design helper arguments
@legaspielaine 

- [x] Accordion
- [x] Blockquote
- [x] Blog Posts
- [x] Button
- [x] Card
- [x] Columns
- [x] Container
- [x] Count Up
- [x] Call to Action
- [x] Divider
- [x] Expand
- [x] Feature Grid
- [x] Feature
- [x] Header
- [x] Heading
- [x] Icon List
- [x] Icon
- [x] Image Box
- [x] Notification
- [x] Number Box
- [x] Pricing Box
- [x] Separator
- [x] Spacer
- [x] Team Member
- [x] Testimonial
- [x] Text
- [x] Video Popup

@legaspielaine I refactored `switchLayouts` assertion helper. 

Instead of just selecting all listed layouts and performing `cy.publish` and `cy.reload` after each iteration, You can now add objects to assert the existence of `ugb` classes corresponding to the selected layout.

accordion.spec.js
```
it( 'should switch layout', switchLayouts( 'ugb/accordion', [
		'Basic',
		'Plain',
		'Line Colored',
		'Colored',
		{ value: 'Plain', selector: '.ugb-accordion--design-plain' },
		{ value: 'Line Colored', selector: '.ugb-accordion--design-line-colored' },
		{ value: 'Colored', selector: '.ugb-accordion--design-colored' },
	] ) )
```

Populate the block selectors.