### PR TITLE
Cypress Configuration

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,8 @@
 	"viewportWidth": 1200,
 	"viewportHeight": 660,
 	"defaultCommandTimeout": 5000,
-	"numTestsKeptInMemory": 5
+	"numTestsKeptInMemory": 5,
+	"env": {
+		"DEBUG": "false"
+	}
 }

--- a/cypress.json
+++ b/cypress.json
@@ -7,6 +7,18 @@
 	"defaultCommandTimeout": 5000,
 	"numTestsKeptInMemory": 5,
 	"env": {
-		"DEBUG": "false"
+		"DEBUG": "false",
+		"includedV2TestFiles": [
+			"accordion",
+			"blockquote",
+			"cta",
+			"divider",
+			"header",
+			"heading",
+			"icon-list",
+			"text"
+		],
+		"includedV3TestFiles": [],
+		"forceIncludeAllTests": "false"
 	}
 }

--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,6 @@
 	"viewportMobileWidth": 360,
 	"viewportWidth": 1200,
 	"viewportHeight": 660,
-	"defaultCommandTimeout": 5000
+	"defaultCommandTimeout": 5000,
+	"numTestsKeptInMemory": 5
 }

--- a/cypress.json
+++ b/cypress.json
@@ -8,7 +8,7 @@
 	"numTestsKeptInMemory": 5,
 	"env": {
 		"DEBUG": "false",
-		"includedV2TestFiles": [
+		"INCLUDED_V2_TEST_FILES": [
 			"accordion",
 			"blockquote",
 			"cta",
@@ -18,7 +18,8 @@
 			"icon-list",
 			"text"
 		],
-		"includedV3TestFiles": [],
-		"forceIncludeAllTests": "false"
+		"INCLUDED_V3_TEST_FILES": [],
+		"FORCE_INCLUDE_ALL_TESTS": "false",
+		"DUMMY_IMAGE_URL": "http://sandbox.gambit.ph/for-test/wp-content/uploads/sites/85/2020/12/avi-richards-ojBNujxI2_c-unsplash.jpg"
 	}
 }

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -43,6 +43,8 @@ function innerBlocks() {
 		blocks
 			.filter( blockName => blockName !== 'ugb/accordion' )
 			.forEach( blockName => cy.appendBlock( blockName ) )
+
+		cy.publish()
 	} )
 }
 

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -156,7 +156,7 @@ function styleTab( viewport, desktopOnly ) {
 		} )
 	} )
 	cy.setBlockAttribute( {
-		[ `container${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: 'http://sandbox.gambit.ph/for-test/wp-content/uploads/sites/85/2020/12/avi-richards-ojBNujxI2_c-unsplash.jpg',
+		[ `container${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
 	} )
 
 	// Test Gradient Background Color

--- a/cypress/integration/v2/blocks/cta.spec.js
+++ b/cypress/integration/v2/blocks/cta.spec.js
@@ -105,14 +105,14 @@ function styleTab( viewport, desktopOnly ) {
 			},
 		} )
 		cy.setBlockAttribute( {
-			[ `columnBackgroundMediaUrl` ]: 'http://sandbox.gambit.ph/for-test/wp-content/uploads/sites/85/2020/12/avi-richards-ojBNujxI2_c-unsplash.jpg',
+			[ `columnBackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
 		} )
 		cy.adjust( 'Background', {
 			[ `Background Media Tint Strength` ]: 7,
 			[ `Fixed Background` ]: true,
 		} ).assertComputedStyle( {
 			'.ugb-cta__item': {
-				[ `background-image` ]: 'url("http://sandbox.gambit.ph/for-test/wp-content/uploads/sites/85/2020/12/avi-richards-ojBNujxI2_c-unsplash.jpg")',
+				[ `background-image` ]: `url("${ Cypress.env( 'DUMMY_IMAGE_URL' ) }")`,
 				[ `background-attachment` ]: 'fixed',
 			},
 			'.ugb-cta__item:before': {
@@ -131,7 +131,7 @@ function styleTab( viewport, desktopOnly ) {
 	} )
 
 	const mobileTabletViewports = [ 'Tablet', 'Mobile' ]
-	cy.setBlockAttribute( { [ `column${ mobileTabletViewports.some( _viewport => _viewport === viewport ) ? viewport : '' }BackgroundMediaUrl` ]: 'http://sandbox.gambit.ph/for-test/wp-content/uploads/sites/85/2020/12/avi-richards-ojBNujxI2_c-unsplash.jpg' } )
+	cy.setBlockAttribute( { [ `column${ mobileTabletViewports.some( _viewport => _viewport === viewport ) ? viewport : '' }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ) } )
 
 	cy.adjust( 'Background', {
 		[ `Adv. Background Image Settings` ]: {

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -91,7 +91,7 @@ function styleTab( viewport, desktopOnly ) {
 
 	cy.collapse( 'Container' )
 	cy.setBlockAttribute( {
-		[ `column${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: 'http://sandbox.gambit.ph/for-test/wp-content/uploads/sites/85/2020/12/avi-richards-ojBNujxI2_c-unsplash.jpg',
+		[ `column${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
 	} )
 	desktopOnly( () => {
 		cy.adjust( 'Background', {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -16,9 +16,9 @@ module.exports = ( on, config ) => {
 		config.env.CYPRESS_NO_COMMAND_LOG = 1
 	}
 
-	if ( config.env.forceIncludeAllTests === 'false' ) {
-		const includeV2TestFiles = config.env.includedV2TestFiles.length && path.join( config.integrationFolder, 'v2', '**', `!(?(${ config.env.includedV2TestFiles.join( '|' ) })).spec.js` )
-		const includeV3TestFiles = config.env.includedV3TestFiles.length && path.join( config.integrationFolder, 'v3', '**', `!(?(${ config.env.includedV3TestFiles.join( '|' ) })).spec.js` )
+	if ( config.env.FORCE_INCLUDE_ALL_TESTS === 'false' ) {
+		const includeV2TestFiles = config.env.INCLUDED_V2_TEST_FILES.length && path.join( config.integrationFolder, 'v2', '**', `!(?(${ config.env.INCLUDED_V2_TEST_FILES.join( '|' ) })).spec.js` )
+		const includeV3TestFiles = config.env.INCLUDED_V3_TEST_FILES.length && path.join( config.integrationFolder, 'v3', '**', `!(?(${ config.env.INCLUDED_V3_TEST_FILES.join( '|' ) })).spec.js` )
 
 		const includeTestFiles = compact( [ includeV2TestFiles, includeV3TestFiles ] ) || []
 		config.ignoreTestFiles = includeTestFiles.length > 1

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,7 +12,7 @@ const FORCE_INCLUDE_ALL = false
 const INCLUDE_V2_TEST_FILES = [
 	// Blocks
 	'accordion',
-	'blockqoute',
+	'blockquote',
 	'cta',
 	'divider',
 	'header',

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -3,8 +3,28 @@
  * @type {Cypress.PluginConfig}
  */
 const webpack = require( '@cypress/webpack-preprocessor' )
+const path = require( 'path' )
+const { compact } = require( 'lodash' )
 
-module.exports = on => {
+// Force all files to be included for debugging.
+const FORCE_INCLUDE_ALL = false
+
+const INCLUDE_V2_TEST_FILES = [
+	// Blocks
+	'accordion',
+	'heading',
+	'blockqoute',
+	'text',
+	'cta',
+	'header',
+	'icon-list',
+	'divider',
+	'spacer',
+]
+
+const INCLUDE_V3_TEST_FILES = []
+
+module.exports = ( on, config ) => {
 	on( `task`, {
 		error( message ) {
 			console.error( message ) // eslint-disable-line no-console
@@ -16,4 +36,15 @@ module.exports = on => {
 		webpackOptions: require( '../../webpack.conf.js' ),
 		watchOptions: {},
 	} ) )
+
+	if ( ! FORCE_INCLUDE_ALL ) {
+		const includeV2TestFiles = INCLUDE_V2_TEST_FILES.length && path.join( config.integrationFolder, 'v2', '**', `!(?(${ INCLUDE_V2_TEST_FILES.join( '|' ) })).spec.js` )
+		const includeV3TestFiles = INCLUDE_V3_TEST_FILES.length && path.join( config.integrationFolder, 'v3', '**', `!(?(${ INCLUDE_V3_TEST_FILES.join( '|' ) })).spec.js` )
+
+		const includeTestFiles = compact( [ includeV2TestFiles, includeV3TestFiles ] ) || []
+		config.ignoreTestFiles = includeTestFiles.length > 1
+			? `{${ includeTestFiles.join( ',' ) }}`
+			: 		includeTestFiles.join( ',' )
+		return config
+	}
 }

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,14 +12,14 @@ const FORCE_INCLUDE_ALL = false
 const INCLUDE_V2_TEST_FILES = [
 	// Blocks
 	'accordion',
-	'heading',
 	'blockqoute',
-	'text',
 	'cta',
-	'header',
-	'icon-list',
 	'divider',
+	'header',
+	'heading',
+	'icon-list',
 	'spacer',
+	'text',
 ]
 
 const INCLUDE_V3_TEST_FILES = []

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -6,24 +6,6 @@ const webpack = require( '@cypress/webpack-preprocessor' )
 const path = require( 'path' )
 const { compact } = require( 'lodash' )
 
-// Force all files to be included for debugging.
-const FORCE_INCLUDE_ALL = false
-
-const INCLUDE_V2_TEST_FILES = [
-	// Blocks
-	'accordion',
-	'blockquote',
-	'cta',
-	'divider',
-	'header',
-	'heading',
-	'icon-list',
-	'spacer',
-	'text',
-]
-
-const INCLUDE_V3_TEST_FILES = []
-
 module.exports = ( on, config ) => {
 	on( `file:preprocessor`, webpack( {
 		webpackOptions: require( '../../webpack.conf.js' ),
@@ -34,9 +16,9 @@ module.exports = ( on, config ) => {
 		config.env.CYPRESS_NO_COMMAND_LOG = 1
 	}
 
-	if ( ! FORCE_INCLUDE_ALL ) {
-		const includeV2TestFiles = INCLUDE_V2_TEST_FILES.length && path.join( config.integrationFolder, 'v2', '**', `!(?(${ INCLUDE_V2_TEST_FILES.join( '|' ) })).spec.js` )
-		const includeV3TestFiles = INCLUDE_V3_TEST_FILES.length && path.join( config.integrationFolder, 'v3', '**', `!(?(${ INCLUDE_V3_TEST_FILES.join( '|' ) })).spec.js` )
+	if ( config.env.forceIncludeAllTests === 'false' ) {
+		const includeV2TestFiles = config.env.includedV2TestFiles.length && path.join( config.integrationFolder, 'v2', '**', `!(?(${ config.env.includedV2TestFiles.join( '|' ) })).spec.js` )
+		const includeV3TestFiles = config.env.includedV3TestFiles.length && path.join( config.integrationFolder, 'v3', '**', `!(?(${ config.env.includedV3TestFiles.join( '|' ) })).spec.js` )
 
 		const includeTestFiles = compact( [ includeV2TestFiles, includeV3TestFiles ] ) || []
 		config.ignoreTestFiles = includeTestFiles.length > 1

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -37,6 +37,10 @@ module.exports = ( on, config ) => {
 		watchOptions: {},
 	} ) )
 
+	if ( config.env.DEBUG === 'false' ) {
+		config.env.CYPRESS_NO_COMMAND_LOG = 1
+	}
+
 	if ( ! FORCE_INCLUDE_ALL ) {
 		const includeV2TestFiles = INCLUDE_V2_TEST_FILES.length && path.join( config.integrationFolder, 'v2', '**', `!(?(${ INCLUDE_V2_TEST_FILES.join( '|' ) })).spec.js` )
 		const includeV3TestFiles = INCLUDE_V3_TEST_FILES.length && path.join( config.integrationFolder, 'v3', '**', `!(?(${ INCLUDE_V3_TEST_FILES.join( '|' ) })).spec.js` )

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -25,13 +25,6 @@ const INCLUDE_V2_TEST_FILES = [
 const INCLUDE_V3_TEST_FILES = []
 
 module.exports = ( on, config ) => {
-	on( `task`, {
-		error( message ) {
-			console.error( message ) // eslint-disable-line no-console
-			return null
-		},
-	} )
-
 	on( `file:preprocessor`, webpack( {
 		webpackOptions: require( '../../webpack.conf.js' ),
 		watchOptions: {},

--- a/cypress/support/advanced.js
+++ b/cypress/support/advanced.js
@@ -62,7 +62,7 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 		cy.openInspector( name, 'Advanced' )
 		_collapse( 'General' )
 
-		 //Test Block HTML Tag
+		// Test Block HTML Tag
 		const tags = [ 'div', 'blockquote', 'section', 'article', 'aside', 'main', 'header', 'footer', 'nav', 'address', 'hgroup' ]
 		tags.forEach( tag => {
 			_adjust( 'Block HTML Tag', tag, { viewport }, 'assertHtmlTag', [
@@ -71,14 +71,14 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 			] )
 		} )
 
-		 //Test Opacity
+		// Test Opacity
 		_adjust( 'Opacity', 0.7, { viewport }, 'assertComputedStyle', [ {
 			[ MAIN_SELECTOR ]: {
 				[ `opacity` ]: '0.7',
 			},
 		} ] )
 
-		 //Test Z-index
+		// Test Z-index
 		_adjust( 'Z-index', 6, { viewport }, 'assertComputedStyle', [ {
 			[ MAIN_SELECTOR ]: {
 				[ `z-index` ]: '6',
@@ -153,7 +153,7 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 		units.forEach( unit => {
 			const values = unit === 'em' ? [ 3, 2, 1, 2 ] : [ 12, 65, 34, 23 ]
 			if ( unit !== 'em' ) {
-				 // Test Block Margins.
+				// Test Block Margins.
 				const [ margins, marginAsserts ] = generateFourRangeControlAssertion(
 					enableMarginTop,
 					enableMarginRight,
@@ -167,7 +167,7 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 				_adjust( 'Block Margins', margins, { unit, viewport }, 'assertComputedStyle', [ { [ BLOCK_SELECTOR ]: marginAsserts } ] )
 			}
 
-			 // Test Block Paddings.
+			// Test Block Paddings.
 			const [ paddings, paddingAsserts ] = generateFourRangeControlAssertion(
 				enablePaddingTop,
 				enablePaddingRight,
@@ -232,13 +232,13 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 		_collapse( 'Responsive' )
 
 		previewMode.forEach( preview => {
-			cy.changePreviewMode( preview )
 			_adjust( `Hide on ${ preview }`, true, {}, 'assertComputedStyle', [ {
 				[ MAIN_SELECTOR ]: {
 					[ `display` ]: 'none',
 				},
 			}, {
 				assertBackend: false,
+				viewportFrontend: preview,
 			} ] )
 		} )
 

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -1,30 +1,3 @@
-import './styles'
-import './global-settings'
-import './setup'
-import './inspector'
-import './attributes'
-
-/**
- * Internal dependencies
- */
-import {
-	containsRegExp, waitLoader,
-} from '../util'
-import { last, first } from 'lodash'
-
-/**
- * Register functions to Cypress Commands.
- */
-Cypress.Commands.add( 'addBlock', addBlock )
-Cypress.Commands.add( 'selectBlock', selectBlock )
-Cypress.Commands.add( 'typeBlock', typeBlock )
-Cypress.Commands.add( 'changePreviewMode', changePreviewMode )
-Cypress.Commands.add( 'deleteBlock', deleteBlock )
-Cypress.Commands.add( 'publish', publish )
-Cypress.Commands.add( 'changeIcon', changeIcon )
-Cypress.Commands.add( 'assertPluginError', assertPluginError )
-Cypress.Commands.add( 'appendBlock', appendBlock )
-Cypress.Commands.add( 'assertBlockError', assertBlockError )
 
 /**
  * Overwrite Cypress Commands
@@ -45,6 +18,34 @@ Cypress.Commands.overwrite( 'first', modifyLogFunc() )
 Cypress.Commands.overwrite( 'wait', modifyLogFunc() )
 Cypress.Commands.overwrite( 'contains', modifyLogFunc() )
 Cypress.Commands.overwrite( 'last', modifyLogFunc() )
+
+/**
+ * Register functions to Cypress Commands.
+ */
+Cypress.Commands.add( 'addBlock', addBlock )
+Cypress.Commands.add( 'selectBlock', selectBlock )
+Cypress.Commands.add( 'typeBlock', typeBlock )
+Cypress.Commands.add( 'changePreviewMode', changePreviewMode )
+Cypress.Commands.add( 'deleteBlock', deleteBlock )
+Cypress.Commands.add( 'publish', publish )
+Cypress.Commands.add( 'changeIcon', changeIcon )
+Cypress.Commands.add( 'assertPluginError', assertPluginError )
+Cypress.Commands.add( 'appendBlock', appendBlock )
+Cypress.Commands.add( 'assertBlockError', assertBlockError )
+
+import './styles'
+import './global-settings'
+import './setup'
+import './inspector'
+import './attributes'
+
+/**
+ * Internal dependencies
+ */
+import {
+	containsRegExp, waitLoader,
+} from '../util'
+import { last, first } from 'lodash'
 
 /**
  * Function for overwriting log argument.

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -10,6 +10,7 @@ import './attributes'
 import {
 	containsRegExp, waitLoader,
 } from '../util'
+import { last, first } from 'lodash'
 
 /**
  * Register functions to Cypress Commands.
@@ -24,6 +25,45 @@ Cypress.Commands.add( 'changeIcon', changeIcon )
 Cypress.Commands.add( 'assertPluginError', assertPluginError )
 Cypress.Commands.add( 'appendBlock', appendBlock )
 Cypress.Commands.add( 'assertBlockError', assertBlockError )
+
+/**
+ * Overwrite Cypress Commands
+ */
+Cypress.Commands.overwrite( 'get', modifyLogFunc() )
+Cypress.Commands.overwrite( 'click', modifyLogFunc() )
+Cypress.Commands.overwrite( 'type', modifyLogFunc() )
+Cypress.Commands.overwrite( 'visit', modifyLogFunc() )
+Cypress.Commands.overwrite( 'reload', modifyLogFunc() )
+Cypress.Commands.overwrite( 'document', modifyLogFunc() )
+Cypress.Commands.overwrite( 'window', modifyLogFunc() )
+Cypress.Commands.overwrite( 'trigger', modifyLogFunc() )
+Cypress.Commands.overwrite( 'parent', modifyLogFunc() )
+Cypress.Commands.overwrite( 'parentsUntil', modifyLogFunc() )
+Cypress.Commands.overwrite( 'invoke', modifyLogFunc( 'first' ) )
+Cypress.Commands.overwrite( 'eq', modifyLogFunc() )
+Cypress.Commands.overwrite( 'first', modifyLogFunc() )
+Cypress.Commands.overwrite( 'wait', modifyLogFunc() )
+Cypress.Commands.overwrite( 'contains', modifyLogFunc() )
+Cypress.Commands.overwrite( 'last', modifyLogFunc() )
+
+/**
+ * Function for overwriting log argument.
+ *
+ * @param {string} position
+ */
+function modifyLogFunc( position = 'last' ) {
+	return function( originalFn, ...args ) {
+		const firstOrLast = position === 'last' ? last : first
+		if ( typeof firstOrLast( args ) === 'object' && ! Array.isArray( firstOrLast( args ) ) ) {
+			const options = args[ position === 'last' ? 'pop' : 'shift' ]()
+			options.log = Cypress.env( 'DEBUG' ) === 'true'
+			return position === 'last' ? originalFn( ...args, options ) : originalFn( options, ...args )
+		}
+		return position === 'last'
+			? 			originalFn( ...args, { log: Cypress.env( 'DEBUG' ) === 'true' } )
+			: 			originalFn( { log: Cypress.env( 'DEBUG' ) === 'true' }, ...args )
+	}
+}
 
 /**
  * Command for clicking the block inserter button

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -127,6 +127,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 		assertFrontend = true,
 		assertBackend = true,
 		wait = false,
+		viewportFrontend = false,
 	} = options
 	getActiveTab( tab => {
 		cy.document().then( doc => {
@@ -157,8 +158,10 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 						getPreviewMode( previewMode => {
 							getAddresses( ( { currUrl, previewUrl } ) => {
 								cy.visit( previewUrl )
-								if ( previewMode !== 'Desktop' ) {
-									cy.viewport( config[ `viewport${ previewMode }Width` ], config.viewportHeight )
+								if ( viewportFrontend && viewportFrontend !== 'Desktop' ) {
+									cy.viewport( config[ `viewport${ viewportFrontend }Width` ] || config.viewportWidth, config.viewportHeight )
+								} else if ( previewMode !== 'Desktop' ) {
+									cy.viewport( config[ `viewport${ previewMode }Width` ] || config.viewportWidth, config.viewportHeight )
 								}
 
 								if ( ! wait || ( wait && wait < 300 ) ) {
@@ -171,9 +174,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 									parsedClassList,
 								} )
 
-								if ( previewMode !== 'Desktop' ) {
-									cy.viewport( config.viewportWidth, config.viewportHeight )
-								}
+								cy.viewport( config.viewportWidth, config.viewportHeight )
 
 								cy.visit( currUrl )
 								cy.get( parsedClassList ).click( { force: true } )

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -138,19 +138,20 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 				.invoke( 'attr', 'class' )
 				.then( classList => {
 					const parsedClassList = parseClassList( classList )
-					if ( wait ) {
+
+					publish()
+
+					if ( ! wait || ( wait && wait < 300 ) ) {
+						cy.wait( 300 )
+					} else {
 						cy.wait( wait )
 					}
-					cy.window().then( editorWin => {
-						cy.document().then( editorDoc => {
-							publish()
-							if ( assertBackend ) {
-								editorCallback( {
-									parsedClassList, win: editorWin, doc: editorDoc,
-								} )
-							}
+
+					if ( assertBackend ) {
+						editorCallback( {
+							parsedClassList,
 						} )
-					} )
+					}
 
 					if ( assertFrontend ) {
 						getPreviewMode( previewMode => {
@@ -160,18 +161,14 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 									cy.viewport( config[ `viewport${ previewMode }Width` ], config.viewportHeight )
 								}
 
-								if ( wait ) {
-									cy.wait( wait )
-								} else {
+								if ( ! wait || ( wait && wait < 300 ) ) {
 									cy.wait( 300 )
+								} else {
+									cy.wait( wait )
 								}
 
-								cy.window().then( frontendWin => {
-									cy.document().then( frontendDoc => {
-										frontendCallback( {
-											parsedClassList, win: frontendWin, doc: frontendDoc,
-										} )
-									} )
+								frontendCallback( {
+									parsedClassList,
 								} )
 
 								if ( previewMode !== 'Desktop' ) {

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -162,6 +162,8 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 
 								if ( wait ) {
 									cy.wait( wait )
+								} else {
+									cy.wait( 300 )
 								}
 
 								cy.window().then( frontendWin => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,15 +1,3 @@
-Cypress.on( `window:before:load`, win => {
-	cy.stub( win.console, `error`, msg => {
-		// log to Terminal
-		cy.now( `task`, `error`, msg )
-		// log to Command Log & fail the test
-		if ( typeof msg === 'string' && msg.match( /stackable|ugb/ ) ) {
-			// Only trigger test fail when the error is stackable related.
-			throw new Error( msg )
-		}
-	} )
-} )
-
 import './commands/index'
 
 // Use Jest assertions

--- a/cypress/support/modules.js
+++ b/cypress/support/modules.js
@@ -191,7 +191,7 @@ export const assertBlockBackground = ( selector, options = {} ) => {
 				},
 			} )
 		} )
-		cy.setBlockAttribute( { [ `blockBackground${ viewport === 'Desktop' ? `` : viewport }BackgroundMediaUrl` ]: 'http://sandbox.gambit.ph/for-test/wp-content/uploads/sites/85/2020/12/avi-richards-ojBNujxI2_c-unsplash.jpg' } )
+		cy.setBlockAttribute( { [ `blockBackground${ viewport === 'Desktop' ? `` : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ) } )
 		desktopOnly( () => {
 			cy.adjust( 'No Paddings', true )
 			cy.adjust( 'Color Type', 'gradient' )

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"test": "cypress open",
 		"lint": "npm run lint-js",
 		"lint-js": "wp-scripts lint-js",
-		"headless": "cypress run --headless --browser chrome"
+		"chrome": "CYPRESS_NO_COMMAND_LOG=1 cypress run --browser chrome"
 	},
 	"keywords": [],
 	"author": "",

--- a/plugin.php
+++ b/plugin.php
@@ -59,7 +59,7 @@ if ( isset( $_GET['setup'] ) ) {
 		if( $user ) {
 			$user_id = $user->ID;
 			wp_set_current_user( $user_id, $user->user_login );
-			wp_set_auth_cookie( $user_id );
+			wp_set_auth_cookie( $user_id, true );
 			do_action( 'wp_login', $user->user_login, $user );
 		}
 


### PR DESCRIPTION
## Cypress Configuration

```
"env": {
    "DEBUG": "false", // If true, display test runner command logging.
    "INCLUDED_V2_TEST_FILES" : [ "accordion", ..... ], // glob representation of test files to be included (v2)
    "INCLUDED_V3_TEST_FILES" : [ "accordion", ..... ], // glob representation of test files to be included (v3)
    "FORCE_INCLUDE_ALL_TESTS" : "false" // If true, run all **.spec.js inside the integration folder directory.
}
```

It is important to only include **passing tests** inside `cypress.json`. Feel free to modify the environment variables for debugging/writing tests. 

#### Passing Test Files (v2):
- accordion.spec.js
- blockquote.spec.js
- cta.spec.js
- divider.spec.js
- header.spec.js
- heading.spec.js
- icon-list.spec.js
- text.spec.js

#### Test Screenshots:
![image](https://user-images.githubusercontent.com/24480990/107106784-4b0d9180-6868-11eb-92b5-3f7bc1cf0ea1.png)
![image](https://user-images.githubusercontent.com/24480990/107106787-51037280-6868-11eb-8cac-8e78f1e51945.png)
![image](https://user-images.githubusercontent.com/24480990/107106793-595bad80-6868-11eb-970e-4ac108f16235.png)
![image](https://user-images.githubusercontent.com/24480990/107106798-624c7f00-6868-11eb-872e-7f5bbeb35013.png)
![image](https://user-images.githubusercontent.com/24480990/107106850-b0618280-6868-11eb-982b-a8fba1efb962.png)
![image](https://user-images.githubusercontent.com/24480990/107106810-77291280-6868-11eb-9c01-955ab3a95e0a.png)
![image](https://user-images.githubusercontent.com/24480990/107107057-ba37b580-6869-11eb-9680-5004d4f1cd7d.png)
![image](https://user-images.githubusercontent.com/24480990/107106826-86a85b80-6868-11eb-8b3e-1309794f0bda.png)






#### Passing Test Files (v3)
- N/A

### Changes:
- Refactored assertion functions (will now remove `transition` css property to all selected elements to avoid inconsistent `getComputedStyle` values)
- Force `assertFunction` to wait 300ms before assertion
- Removed console error stubs for performance boost. (use `cy.assertBlockError` to check block errors instead)
- Overwrites Cypress functions to control logging options ( set `env.DEBUG = "fase"` to append `{ log: false }` to all Cypress commands)
- Increased user login session timeout 
