### PR TITLE
Code cleanup

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -18,7 +18,6 @@
 			"feature-grid",
 			"header",
 			"heading",
-			"icon",
 			"icon-list",
 			"separator",
 			"spacer",

--- a/cypress.json
+++ b/cypress.json
@@ -18,6 +18,7 @@
 			"feature-grid",
 			"header",
 			"heading",
+			"icon",
 			"icon-list",
 			"separator",
 			"spacer",

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -273,8 +273,6 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-accordion__heading': {
 				[ `margin-bottom` ]: '63px',
 			},
-		}, {
-			wait: 1000,
 		} )
 
 	// Test Title options

--- a/cypress/integration/v2/blocks/blockquote.spec.js
+++ b/cypress/integration/v2/blocks/blockquote.spec.js
@@ -73,7 +73,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `padding-right` ]: '25px',
 			[ `padding-left` ]: '25px',
 		},
-	}, { wait: 300 } )
+	} )
 	cy.resetStyle( 'Paddings' )
 	cy.adjust( 'Paddings', 3, { viewport, unit: 'em' } ).assertComputedStyle( {
 		'.ugb-blockquote__item': {
@@ -82,7 +82,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `padding-right` ]: '3em',
 			[ `padding-left` ]: '3em',
 		},
-	}, { wait: 300 } )
+	} )
 	cy.resetStyle( 'Paddings' )
 	cy.adjust( 'Paddings', 17, { viewport, unit: '%' } ).assertComputedStyle( {
 		'.ugb-blockquote__item': {
@@ -91,7 +91,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `padding-right` ]: '17%',
 			[ `padding-left` ]: '17%',
 		},
-	}, { wait: 300 } )
+	} )
 
 	// Test Quotation Mark options
 	cy.collapse( 'Quotation Mark' )

--- a/cypress/integration/v2/blocks/button.spec.js
+++ b/cypress/integration/v2/blocks/button.spec.js
@@ -59,7 +59,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-block-content .ugb-button': {
 				[ `border-radius` ]: '20px',
 			},
-		}, { wait: 300 } )
+		} )
 		cy.adjust( 'Collapse Buttons On', 'tablet' )
 			.assertClassName( '.ugb-button-wrapper', 'ugb-button--collapse-tablet' )
 	} )
@@ -171,7 +171,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button1 .ugb-button--inner': {
 				[ `font-size` ]: '31px',
 			},
-		}, { wait: 300 } )
+		} )
 
 		cy.adjust( 'Typography', {
 			[ `Size` ]: {
@@ -183,7 +183,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button1 .ugb-button--inner': {
 				[ `font-size` ]: '7em',
 			},
-		}, { wait: 300 } )
+		} )
 	}
 
 	cy.collapse( 'Button #2' )
@@ -268,7 +268,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button2 .ugb-button--inner': {
 				[ `font-size` ]: '31px',
 			},
-		}, { wait: 300 } )
+		} )
 
 		cy.adjust( 'Typography', {
 			[ `Size` ]: {
@@ -280,7 +280,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button2 .ugb-button--inner': {
 				[ `font-size` ]: '7em',
 			},
-		}, { wait: 300 } )
+		} )
 	}
 
 	cy.collapse( 'Button #3' )
@@ -365,7 +365,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button3 .ugb-button--inner': {
 				[ `font-size` ]: '31px',
 			},
-		}, { wait: 300 } )
+		} )
 
 		cy.adjust( 'Typography', {
 			[ `Size` ]: {
@@ -377,7 +377,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button3 .ugb-button--inner': {
 				[ `font-size` ]: '7em',
 			},
-		}, { wait: 300 } )
+		} )
 	}
 
 	assertBlockBackground( '.ugb-button-wrapper', { viewport } )

--- a/cypress/integration/v2/blocks/expand.spec.js
+++ b/cypress/integration/v2/blocks/expand.spec.js
@@ -87,7 +87,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-expand__title', { viewport } )
 
@@ -144,7 +144,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-expand__less-text p, .ugb-expand__more-text p', { viewport } )
 
@@ -201,7 +201,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-expand__more-toggle-text, .ugb-expand__less-toggle-text', { viewport } )
 

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -181,19 +181,19 @@ function styleTab( viewport, desktopOnly ) {
 			[ `margin-left` ]: '0px',
 			[ `margin-right` ]: 'auto',
 		},
-	}, { wait: 500 } )
+	} )
 	cy.adjust( 'Align', 'center', { viewport } ).assertComputedStyle( {
 		'.ugb-feature-grid__image': {
 			[ `margin-left` ]: 'auto',
 			[ `margin-right` ]: 'auto',
 		},
-	}, { wait: 500 } )
+	} )
 	cy.adjust( 'Align', 'right', { viewport } ).assertComputedStyle( {
 		'.ugb-feature-grid__image': {
 			[ `margin-left` ]: 'auto',
 			[ `margin-right` ]: '0px',
 		},
-	}, { wait: 500 } )
+	} )
 
 	desktopOnly( () => {
 		cy.adjust( 'Shape', {
@@ -261,7 +261,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-feature-grid__title', { viewport } )
 
@@ -316,7 +316,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-feature-grid__description', { viewport } )
 
@@ -335,7 +335,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `Letter Spacing` ]: 2.9,
 		} )
 		cy.adjust( 'Button Size', 'large' )
-			.assertClassName( '.ugb-button', 'ugb-button--size-large', { wait: 1000 } )
+			.assertClassName( '.ugb-button', 'ugb-button--size-large' )
 		cy.adjust( 'Opacity', 0.2 ).assertComputedStyle( {
 			'.ugb-button .ugb-button--inner': {
 				[ `font-weight` ]: '700',
@@ -367,7 +367,7 @@ function styleTab( viewport, desktopOnly ) {
 		'.ugb-button .ugb-button--inner': {
 			[ `font-size` ]: '50px',
 		},
-	}, { wait: 500 } )
+	} )
 
 	cy.adjust( 'Typography', {
 		[ `Size` ]: {
@@ -379,7 +379,7 @@ function styleTab( viewport, desktopOnly ) {
 		'.ugb-button .ugb-button--inner': {
 			[ `font-size` ]: '7em',
 		},
-	}, { wait: 500 } )
+	} )
 
 	desktopOnly( () => {
 		cy.collapse( 'Effects' )

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -438,7 +438,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button1 .ugb-button--inner': {
 				[ `font-size` ]: '50px',
 			},
-		}, { wait: 300 } )
+		}, { wait: 600 } )
 
 		cy.adjust( 'Typography', {
 			[ `Size` ]: {
@@ -450,7 +450,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button1 .ugb-button--inner': {
 				[ `font-size` ]: '7em',
 			},
-		}, { wait: 300 } )
+		}, { wait: 600 } )
 	}
 
 	cy.collapse( 'Button #2' )
@@ -534,7 +534,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button2 .ugb-button--inner': {
 				[ `font-size` ]: '50px',
 			},
-		}, { wait: 300 } )
+		}, { wait: 600 } )
 
 		cy.adjust( 'Typography', {
 			[ `Size` ]: {
@@ -546,7 +546,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button2 .ugb-button--inner': {
 				[ `font-size` ]: '7em',
 			},
-		}, { wait: 300 } )
+		}, { wait: 600 } )
 	}
 
 	cy.adjust( 'Align', 'left', { viewport } ).assertComputedStyle( {

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -297,7 +297,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-header__title', { viewport } )
 
@@ -353,7 +353,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-header__subtitle', { viewport } )
 
@@ -438,7 +438,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button1 .ugb-button--inner': {
 				[ `font-size` ]: '50px',
 			},
-		}, { wait: 600 } )
+		} )
 
 		cy.adjust( 'Typography', {
 			[ `Size` ]: {
@@ -450,7 +450,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button1 .ugb-button--inner': {
 				[ `font-size` ]: '7em',
 			},
-		}, { wait: 600 } )
+		} )
 	}
 
 	cy.collapse( 'Button #2' )
@@ -534,7 +534,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button2 .ugb-button--inner': {
 				[ `font-size` ]: '50px',
 			},
-		}, { wait: 600 } )
+		} )
 
 		cy.adjust( 'Typography', {
 			[ `Size` ]: {
@@ -546,7 +546,7 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-button2 .ugb-button--inner': {
 				[ `font-size` ]: '7em',
 			},
-		}, { wait: 600 } )
+		} )
 	}
 
 	cy.adjust( 'Align', 'left', { viewport } ).assertComputedStyle( {

--- a/cypress/integration/v2/blocks/heading.spec.js
+++ b/cypress/integration/v2/blocks/heading.spec.js
@@ -90,7 +90,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-heading__title', { viewport } )
 
@@ -148,7 +148,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `line-height` ]: '24px',
 			[ `color` ]: '#742f2f',
 		},
-	}, { wait: 300 } )
+	} )
 
 	assertAligns( 'Align', '.ugb-heading__subtitle', { viewport } )
 

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -64,7 +64,7 @@ function styleTab( viewport, desktopOnly ) {
 		'.ugb-icon-list ul': {
 			[ `columns` ]: 'auto 4',
 		},
-	}, { wait: 300 } )
+	} )
 	desktopOnly( () => {
 		cy.adjust( 'Display as a grid (left to right & evenly spaced)', true )
 	} )
@@ -117,7 +117,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `font-size` ]: '50px',
 			[ `line-height` ]: '4em',
 		},
-	}, { wait: 300 } )
+	} )
 
 	cy.adjust( 'Typography', {
 		[ `Size` ]: {
@@ -135,7 +135,7 @@ function styleTab( viewport, desktopOnly ) {
 			[ `font-size` ]: '7em',
 			[ `line-height` ]: '24px',
 		},
-	}, { wait: 300 } )
+	} )
 
 	desktopOnly( () => {
 		cy.adjust( 'Typography', {
@@ -154,7 +154,7 @@ function styleTab( viewport, desktopOnly ) {
 			li: {
 				[ `color` ]: '#742f2f',
 			},
-		}, { wait: 300 } )
+		} )
 	} )
 
 	assertBlockTitleDescription( { viewport } )

--- a/cypress/integration/v2/blocks/icon.spec.js
+++ b/cypress/integration/v2/blocks/icon.spec.js
@@ -55,13 +55,15 @@ function desktopStyle() {
 		// Test Title options
 		cy.collapse( 'Title' )
 		cy.toggleStyle( 'Title' )
-		cy.adjust( 'Title on Top', true )
+
 		cy.typeBlock( 'ugb/icon', '.ugb-icon__item1 .ugb-icon__title', 'Title 1' )
 		cy.typeBlock( 'ugb/icon', '.ugb-icon__item2 .ugb-icon__title', 'Title 2' )
 		cy.typeBlock( 'ugb/icon', '.ugb-icon__item3 .ugb-icon__title', 'Title 3' )
 		cy.typeBlock( 'ugb/icon', '.ugb-icon__item4 .ugb-icon__title', 'Title 4' )
+
 		cy.adjust( 'Title HTML Tag', 'h4' )
 			.assertHtmlTag( '.ugb-icon__title', 'h4' )
+		cy.adjust( 'Title on Top', true )
 		cy.adjust( 'Typography', {
 			[ `Font Family` ]: 'Serif',
 			[ `Size` ]: 18,
@@ -183,7 +185,7 @@ function desktopStyle() {
 		} )
 
 		// Test Block Background
-		assertBlockBackground( { viewport: 'Desktop' } )
+		assertBlockBackground( '.ugb-icon', { viewport: 'Desktop' } )
 
 		// Test Top and Bottom Separator
 		assertSeparators( { viewport: 'Desktop' } )
@@ -427,7 +429,7 @@ function mobileStyle() {
 		} )
 
 		// Test Block Background.
-		assertBlockBackground( { viewport: 'Mobile' } )
+		assertBlockBackground( '.ugb-icon', { viewport: 'Mobile' } )
 
 		// Test Top and Bottom Separator.
 		assertSeparators( { viewport: 'Mobile' } )

--- a/cypress/integration/v2/blocks/separator.spec.js
+++ b/cypress/integration/v2/blocks/separator.spec.js
@@ -183,31 +183,23 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-separator__top-pad': {
 				[ `height` ]: '126px',
 			},
-		}, {
-			wait: 500,
 		} )
 		cy.resetStyle( 'Padding Top' )
 		cy.adjust( 'Padding Top', 40, { viewport, unit: 'em' } ).assertComputedStyle( {
 			'.ugb-separator__top-pad': {
 				[ `height` ]: '40em',
 			},
-		}, {
-			wait: 500,
 		} )
 		cy.adjust( 'Padding Bottom', 111, { viewport, unit: 'px' } ).assertComputedStyle( {
 			'.ugb-separator__bottom-pad': {
 				[ `height` ]: '111px',
 			},
-		}, {
-			wait: 500,
 		} )
 		cy.resetStyle( 'Padding Bottom' )
 		cy.adjust( 'Padding Bottom', 36, { viewport, unit: 'em' } ).assertComputedStyle( {
 			'.ugb-separator__bottom-pad': {
 				[ `height` ]: '36em',
 			},
-		}, {
-			wait: 500,
 		} )
 
 		/**
@@ -219,15 +211,11 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-separator': {
 				[ `margin-top` ]: '19px',
 			},
-		}, {
-			wait: 500,
 		} )
 		cy.adjust( 'Margin Top', 25, { viewport, unit: '%' } ).assertComputedStyle( {
 			'.ugb-separator': {
 				[ `margin-top` ]: '24%',
 			},
-		}, {
-			wait: 500,
 		} )
 
 		// Test Margin Bottom
@@ -235,15 +223,11 @@ function styleTab( viewport, desktopOnly ) {
 			'.ugb-separator': {
 				[ `margin-bottom` ]: '34px',
 			},
-		}, {
-			wait: 500,
 		} )
 		cy.adjust( 'Margin Bottom', 40, { viewport, unit: '%' } ).assertComputedStyle( {
 			'.ugb-separator': {
 				[ `margin-bottom` ]: '39%',
 			},
-		}, {
-			wait: 500,
 		} )
 	}
 

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -109,7 +109,7 @@ export function selectBlock( subject, selector ) {
 		.invoke( 'attr', 'data-block' )
 		.then( dataBlock => {
 			cy.window().then( win => {
-				if ( dataBlock && win.wp.data.select( 'core/block-editor' ).getSelectedBlockClientId() !== dataBlock ) {
+				if ( win.wp.data.select( 'core/block-editor' ).getSelectedBlockClientId() !== dataBlock ) {
 					win.wp.data.dispatch( 'core/block-editor' ).selectBlock( dataBlock )
 					cy.wait( 100 )
 				}

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -87,7 +87,7 @@ export function addBlock( blockname = 'ugb/accordion' ) {
  */
 export function selectBlock( subject, selector ) {
 // Initialize chained command based on selector type.
-	if ( ! selector ) {
+	if ( selector === '' ) {
 		selector = undefined
 	}
 

--- a/cypress/support/commands/inspector.js
+++ b/cypress/support/commands/inspector.js
@@ -25,6 +25,7 @@ export function openSidebar( label = 'Settings' ) {
 
 	cy.window().then( win => {
 		win.wp.data.dispatch( 'core/edit-post' ).openGeneralSidebar( sidebarNamespace[ label ] )
+		cy.wait( 100 )
 	} )
 }
 
@@ -37,8 +38,8 @@ export function openSidebar( label = 'Settings' ) {
  */
 export function openInspector( subject, tab, selector ) {
 	selectBlock( subject, selector )
-	openSidebar( 'Settings' )
 
+	openSidebar( 'Settings' )
 	cy
 		.get( `button.edit-post-sidebar__panel-tab` )
 		.contains( containsRegExp( tab ) )

--- a/cypress/support/commands/inspector.js
+++ b/cypress/support/commands/inspector.js
@@ -42,6 +42,11 @@ export function openInspector( subject, tab, selector ) {
 	openSidebar( 'Settings' )
 	cy
 		.get( `button.edit-post-sidebar__panel-tab` )
+		.contains( containsRegExp( 'Block' ) )
+		.click( { force: true } )
+
+	cy
+		.get( `button.edit-post-sidebar__panel-tab` )
 		.contains( containsRegExp( tab ) )
 		.click( { force: true } )
 }

--- a/cypress/support/commands/inspector.js
+++ b/cypress/support/commands/inspector.js
@@ -18,17 +18,14 @@ Cypress.Commands.add( 'toggleStyle', toggleStyle )
  * @param {string} label
  */
 export function openSidebar( label = 'Settings' ) {
-	cy
-		.get( `button[aria-label="${ label }"]` )
-		.invoke( 'attr', 'aria-expanded' )
-		.then( ariaExpanded => {
-			// Open the inspector first if not visible.
-			if ( ariaExpanded === 'false' ) {
-				cy
-					.get( `button[aria-label="${ label }"]` )
-					.click( { force: true } )
-			}
-		} )
+	const sidebarNamespace = {
+		[ `Settings` ]: 'edit-post/block',
+		[ `Stackable Settings` ]: 'stackable-global-settings/sidebar',
+	}
+
+	cy.window().then( win => {
+		win.wp.data.dispatch( 'core/edit-post' ).openGeneralSidebar( sidebarNamespace[ label ] )
+	} )
 }
 
 /**
@@ -40,18 +37,12 @@ export function openSidebar( label = 'Settings' ) {
  */
 export function openInspector( subject, tab, selector ) {
 	selectBlock( subject, selector )
-	cy.document().then( doc => {
-		if ( ! doc.querySelector( '.is-selected' ) ) {
-			selectBlock( subject, selector )
-		}
+	openSidebar( 'Settings' )
 
-		openSidebar( 'Settings' )
-
-		cy
-			.get( `button.edit-post-sidebar__panel-tab` )
-			.contains( containsRegExp( tab ) )
-			.click( { force: true } )
-	} )
+	cy
+		.get( `button.edit-post-sidebar__panel-tab` )
+		.contains( containsRegExp( tab ) )
+		.click( { force: true } )
 }
 
 /**
@@ -61,48 +52,42 @@ export function openInspector( subject, tab, selector ) {
  * @param {boolean} toggle
  */
 export function collapse( name = 'General', toggle = true ) {
-	cy
-		.document()
-		.then( doc => {
-			const globalSettingsElement = doc.querySelector( '.ugb-global-settings__inspector' )
+	getActiveTab( tab => {
+		if ( tab === 'Stackable Global Settings' ) {
+			return cy
+				.get( 'button.components-panel__body-toggle' )
+				.contains( containsRegExp( name ) )
+				.invoke( 'attr', 'aria-expanded' )
+				.then( ariaExpanded => {
+					if ( ariaExpanded !== toggle.toString() ) {
+						cy
+							.get( 'button.components-panel__body-toggle' )
+							.contains( containsRegExp( name ) )
+							.click( { force: true } )
+					}
+				} )
+		}
 
-			if ( globalSettingsElement ) {
-				cy
-					.get( 'button.components-panel__body-toggle' )
-					.contains( containsRegExp( name ) )
-					.invoke( 'attr', 'aria-expanded' )
-					.then( ariaExpanded => {
-						if ( ariaExpanded !== toggle.toString() ) {
-							cy
-								.get( 'button.components-panel__body-toggle' )
-								.contains( containsRegExp( name ) )
-								.click( { force: true } )
-						}
-					} )
-			} else {
-				getActiveTab( tab => {
+		return cy
+			.get( `.ugb-panel-${ tab }>.components-panel__body .components-panel__body-title` )
+			.contains( containsRegExp( name ) )
+			.parentsUntil( `.ugb-panel-${ tab }>.components-panel__body` )
+			.parent()
+			.find( 'button.components-panel__body-toggle' )
+			.invoke( 'attr', 'aria-expanded' )
+			.then( ariaExpanded => {
+				// Open the accordion if aria-expanded is false.
+				if ( ariaExpanded !== toggle.toString() ) {
 					cy
 						.get( `.ugb-panel-${ tab }>.components-panel__body .components-panel__body-title` )
 						.contains( containsRegExp( name ) )
 						.parentsUntil( `.ugb-panel-${ tab }>.components-panel__body` )
 						.parent()
 						.find( 'button.components-panel__body-toggle' )
-						.invoke( 'attr', 'aria-expanded' )
-						.then( ariaExpanded => {
-							// Open the accordion if aria-expanded is false.
-							if ( ariaExpanded !== toggle.toString() ) {
-								cy
-									.get( `.ugb-panel-${ tab }>.components-panel__body .components-panel__body-title` )
-									.contains( containsRegExp( name ) )
-									.parentsUntil( `.ugb-panel-${ tab }>.components-panel__body` )
-									.parent()
-									.find( 'button.components-panel__body-toggle' )
-									.click( { force: true } )
-							}
-						} )
-				} )
-			}
-		} )
+						.click( { force: true } )
+				}
+			} )
+	} )
 }
 
 /**

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -12,7 +12,7 @@ import { collapse, openSidebar } from './commands/inspector'
  * External dependencies
  */
 import {
-	startCase, lowerCase,
+	startCase, lowerCase, max,
 } from 'lodash'
 
 /**
@@ -142,7 +142,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 
 					publish()
 
-					cy.wait( wait < 1000 ? 1000 : wait )
+					cy.wait( max( [ 1000, wait ] ) )
 
 					if ( assertBackend ) {
 						getPreviewMode( previewMode => {
@@ -162,7 +162,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 									cy.viewport( config[ `viewport${ previewMode }Width` ] || config.viewportWidth, config.viewportHeight )
 								}
 
-								cy.wait( wait < 1000 ? 1000 : wait )
+								cy.wait( max( [ 1000, wait ] ) )
 
 								frontendCallback( {
 									parsedClassList, viewport: previewMode,

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -127,7 +127,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 	const {
 		assertFrontend = true,
 		assertBackend = true,
-		wait = false,
+		wait = 300,
 		viewportFrontend = false,
 	} = options
 	getActiveTab( tab => {
@@ -143,11 +143,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 
 					publish()
 
-					if ( ! wait || ( wait && wait < 300 ) ) {
-						cy.wait( 300 )
-					} else {
-						cy.wait( wait )
-					}
+					cy.wait( wait )
 
 					if ( assertBackend ) {
 						getPreviewMode( previewMode => {
@@ -167,11 +163,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 									cy.viewport( config[ `viewport${ previewMode }Width` ] || config.viewportWidth, config.viewportHeight )
 								}
 
-								if ( ! wait || ( wait && wait < 300 ) ) {
-									cy.wait( 300 )
-								} else {
-									cy.wait( wait )
-								}
+								cy.wait( wait )
 
 								frontendCallback( {
 									parsedClassList, viewport: previewMode,

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -126,7 +126,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 	const {
 		assertFrontend = true,
 		assertBackend = true,
-		wait = 400,
+		wait = 1000,
 		viewportFrontend = false,
 	} = options
 	getActiveTab( tab => {
@@ -142,7 +142,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 
 					publish()
 
-					cy.wait( wait < 400 ? 400 : wait )
+					cy.wait( wait < 1000 ? 1000 : wait )
 
 					if ( assertBackend ) {
 						getPreviewMode( previewMode => {
@@ -162,7 +162,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 									cy.viewport( config[ `viewport${ previewMode }Width` ] || config.viewportWidth, config.viewportHeight )
 								}
 
-								cy.wait( wait < 400 ? 400 : wait )
+								cy.wait( wait < 1000 ? 1000 : wait )
 
 								frontendCallback( {
 									parsedClassList, viewport: previewMode,

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -66,7 +66,6 @@ export const switchDesigns = ( blockName = 'ugb/accordion', designs = [] ) => ()
 	cy.newPage()
 	cy.addBlock( blockName )
 	designs.forEach( design => {
-		cy.wait( 300 )
 		cy.openInspector( blockName, 'Layout' )
 		cy.adjustDesign( design )
 		cy.publish()
@@ -127,7 +126,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 	const {
 		assertFrontend = true,
 		assertBackend = true,
-		wait = 300,
+		wait = 400,
 		viewportFrontend = false,
 	} = options
 	getActiveTab( tab => {
@@ -143,7 +142,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 
 					publish()
 
-					cy.wait( wait )
+					cy.wait( wait < 400 ? 400 : wait )
 
 					if ( assertBackend ) {
 						getPreviewMode( previewMode => {
@@ -163,7 +162,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 									cy.viewport( config[ `viewport${ previewMode }Width` ] || config.viewportWidth, config.viewportHeight )
 								}
 
-								cy.wait( wait )
+								cy.wait( wait < 400 ? 400 : wait )
 
 								frontendCallback( {
 									parsedClassList, viewport: previewMode,

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -23,7 +23,7 @@ export const getBaseControl = ( tab = 'style', isInPopover = false ) => {
  * @param {string} name
  * @return {RegExp} generated RegExp
  */
-export const containsRegExp = ( name = '' ) => new RegExp( `^${ name.replace( /[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g, '\\$&' ) }$` )
+export const containsRegExp = ( name = '' ) => new RegExp( `^${ ( typeof name !== 'string' ? '' : name ).replace( /[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g, '\\$&' ) }$` )
 
 /**
  * Function for getting the active tab


### PR DESCRIPTION
### Code Changes:

- Minor `icon.spec.js` refactor ( we still need to use responsiveAssertHelper here)
- Minor `header.spec.js` refactor ( adjusted `wait` to avoid random failing tests )
- Minor code tweaks (for readability)
- `wp.data` support in `selectBlock` command (our current `selectBlock` is unstable due to lack of `.is-selected` checking)
- `wp-data` support in `openSidebar` command

### TODOs

- [x] All test files passed
![Screen Shot 2021-02-10 at 10 43 46 AM](https://user-images.githubusercontent.com/24480990/107457348-dcdd0d80-6b8c-11eb-9723-7c37a048d0b3.png)
![Screen Shot 2021-02-10 at 10 43 58 AM](https://user-images.githubusercontent.com/24480990/107457360-e2d2ee80-6b8c-11eb-8054-f70bbf3a7b74.png)
![Screen Shot 2021-02-10 at 10 44 27 AM](https://user-images.githubusercontent.com/24480990/107457400-f4b49180-6b8c-11eb-8344-2edf02727ad0.png)
![Screen Shot 2021-02-10 at 10 44 41 AM](https://user-images.githubusercontent.com/24480990/107457416-fc743600-6b8c-11eb-9783-95f90a9795a5.png)
![Screen Shot 2021-02-10 at 10 44 53 AM](https://user-images.githubusercontent.com/24480990/107457432-039b4400-6b8d-11eb-8016-3b499eb67fe5.png)
![Screen Shot 2021-02-10 at 10 45 08 AM](https://user-images.githubusercontent.com/24480990/107457459-0d24ac00-6b8d-11eb-8491-ebe52a03f8e0.png)
![Screen Shot 2021-02-10 at 10 59 07 AM](https://user-images.githubusercontent.com/24480990/107458415-06973400-6b8f-11eb-8f60-7e21cafd33e3.png)
![Screen Shot 2021-02-10 at 12 05 40 PM](https://user-images.githubusercontent.com/24480990/107463022-4dd5f280-6b98-11eb-925c-b65cd4a86ab1.png)
![Screen Shot 2021-02-10 at 11 16 46 AM](https://user-images.githubusercontent.com/24480990/107459588-79091380-6b91-11eb-95e6-da5f0b850b23.png)
![Screen Shot 2021-02-10 at 12 18 19 PM](https://user-images.githubusercontent.com/24480990/107463904-110afb00-6b9a-11eb-9097-73e90bec8338.png)
![Screen Shot 2021-02-10 at 12 17 50 PM](https://user-images.githubusercontent.com/24480990/107463874-00f31b80-6b9a-11eb-98a8-8cf1cd8c5ebe.png)
![Screen Shot 2021-02-10 at 12 19 45 PM](https://user-images.githubusercontent.com/24480990/107463995-457eb700-6b9a-11eb-8fb9-8a11fc6bbd46.png)
![Screen Shot 2021-02-10 at 12 44 43 PM](https://user-images.githubusercontent.com/24480990/107465692-c8edd780-6b9d-11eb-8f6f-6de7553119c5.png)
