### PR TITLE
Experimental block snapshots

### DIFF
--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -61,7 +61,7 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
 
@@ -131,7 +131,7 @@ function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots )
 	} )
 
 	cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )
-	const accordionBlock = __experimentalRegisterBlockSnapshots( 'accordionBlock' )
+	const accordionBlock = registerBlockSnapshots( 'accordionBlock' )
 
 	// Test General Alignment
 	cy.openInspector( 'ugb/accordion', 'Style' )

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -5,7 +5,7 @@
 import { range } from 'lodash'
 import { blocks } from '~stackable-e2e/config'
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, assertAligns, registerTests, responsiveAssertHelper, assertTypography,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, assertAligns, registerTests, responsiveAssertHelper, assertTypography, assertContainer,
 } from '~stackable-e2e/helpers'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -61,7 +61,7 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
 
@@ -129,7 +129,9 @@ function styleTab( viewport, desktopOnly ) {
 		} )
 		cy.deleteBlock( 'ugb/accordion', 'Accordion 1' )
 	} )
-	cy.addBlock( 'ugb/accordion' )
+
+	cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )
+	const accordionBlock = __experimentalRegisterBlockSnapshots( 'accordionBlock' )
 
 	// Test General Alignment
 	cy.openInspector( 'ugb/accordion', 'Style' )
@@ -139,110 +141,8 @@ function styleTab( viewport, desktopOnly ) {
 
 	cy.collapse( 'Container' )
 
-	// Test Single Background Color
-	desktopOnly( () => {
-		cy.adjust( 'Background', {
-			'Color Type': 'single',
-			'Background Color': '#000000',
-			'Background Color Opacity': '0.5',
-		} ).assertComputedStyle( {
-			'.ugb-accordion__heading': {
-				'background-color': 'rgba(0, 0, 0, 0.5)',
-			},
-		} )
-	} )
-	cy.setBlockAttribute( {
-		[ `container${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
-	} )
-
-	// Test Gradient Background Color
-	desktopOnly( () => {
-		cy.adjust( 'Background', {
-			'Color Type': 'gradient',
-			'Background Color #1': '#f00069',
-			'Background Color #2': '#000000',
-			'Adv. Gradient Color Settings': {
-				'Gradient Direction (degrees)': '180deg',
-				'Color 1 Location': '11%',
-				'Color 2 Location': '80%',
-				'Background Gradient Blend Mode': 'hard-light',
-			},
-			'Background Media Tint Strength': 6,
-			'Fixed Background': true,
-			'Adv. Background Image Settings': {
-				'Image Blend Mode': 'hue',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-accordion__heading:before': {
-				'background-image': 'linear-gradient(#f00069 11%, #000000 80%)',
-				'mix-blend-mode': 'hard-light',
-				'opacity': '0.6',
-			},
-			'.ugb-accordion__heading': {
-				'background-blend-mode': 'hue',
-				'background-attachment': 'fixed',
-			},
-		} )
-	} )
-
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Position': {
-				viewport,
-				value: 'center center',
-			},
-			'Image Repeat': {
-				viewport,
-				value: 'repeat-x',
-			},
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 19,
-				unit: '%',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-accordion__heading': {
-			'background-position': '50% 50%',
-			'background-repeat': 'repeat-x',
-			'background-size': '19%',
-		},
-	} )
-
-	// Test Border Radius
-	desktopOnly( () => {
-		cy.adjust( 'Border Radius', 30 ).assertComputedStyle( {
-			'.ugb-accordion__heading': {
-				'border-radius': '30px',
-			},
-		} )
-	} )
-
-	// Test Border Options
-	desktopOnly( () => {
-		cy.adjust( 'Borders', 'solid' )
-		cy.adjust( 'Border Width', 3 )
-		cy.adjust( 'Border Color', '#f1f1f1' ).assertComputedStyle( {
-			'.ugb-accordion__heading': {
-				'border-style': 'solid',
-				'border-color': '#f1f1f1',
-				'border-top-width': '3px',
-				'border-bottom-width': '3px',
-				'border-left-width': '3px',
-				'border-right-width': '3px',
-			},
-		} )
-	} )
-
-	// Test Shadow / Outline
-	desktopOnly( () => {
-		cy.adjust( 'Shadow / Outline', 9 )
-			.assertClassName( '.ugb-accordion__heading', 'ugb--shadow-9' )
-	} )
+	// Test Container
+	assertContainer( '.ugb-accordion__heading', { viewport }, 'container%sBackgroundMediaUrl' )
 
 	cy.collapse( 'Spacing' )
 	// Test Padding options
@@ -299,4 +199,6 @@ function styleTab( viewport, desktopOnly ) {
 				},
 			} )
 	} )
+
+	accordionBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/blockquote.spec.js
+++ b/cypress/integration/v2/blocks/blockquote.spec.js
@@ -54,10 +54,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/blockquote' )
+	cy.addBlock( 'ugb/blockquote' ).as( 'blockquoteBlock' )
+	const blockquoteBlock = __experimentalRegisterBlockSnapshots( 'blockquoteBlock' )
 	cy.openInspector( 'ugb/blockquote', 'Style' )
 
 	// Test General Alignment
@@ -134,5 +135,6 @@ function styleTab( viewport, desktopOnly ) {
 	assertBlockBackground( '.ugb-blockquote', { viewport } )
 
 	assertSeparators( { viewport } )
+	blockquoteBlock.assertFrontendStyles()
 }
 

--- a/cypress/integration/v2/blocks/blockquote.spec.js
+++ b/cypress/integration/v2/blocks/blockquote.spec.js
@@ -54,11 +54,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/blockquote' ).as( 'blockquoteBlock' )
-	const blockquoteBlock = __experimentalRegisterBlockSnapshots( 'blockquoteBlock' )
+	const blockquoteBlock = registerBlockSnapshots( 'blockquoteBlock' )
 	cy.openInspector( 'ugb/blockquote', 'Style' )
 
 	// Test General Alignment

--- a/cypress/integration/v2/blocks/button.spec.js
+++ b/cypress/integration/v2/blocks/button.spec.js
@@ -46,11 +46,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/button' ).as( 'buttonBlock' )
-	const buttonBlock = __experimentalRegisterBlockSnapshots( 'buttonBlock' )
+	const buttonBlock = registerBlockSnapshots( 'buttonBlock' )
 	cy.openInspector( 'ugb/button', 'Style' )
 
 	cy.collapse( 'General' )

--- a/cypress/integration/v2/blocks/button.spec.js
+++ b/cypress/integration/v2/blocks/button.spec.js
@@ -46,10 +46,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/button' )
+	cy.addBlock( 'ugb/button' ).as( 'buttonBlock' )
+	const buttonBlock = __experimentalRegisterBlockSnapshots( 'buttonBlock' )
 	cy.openInspector( 'ugb/button', 'Style' )
 
 	cy.collapse( 'General' )
@@ -385,4 +386,5 @@ function styleTab( viewport, desktopOnly ) {
 
 	assertBlockBackground( '.ugb-button-wrapper', { viewport } )
 	assertSeparators( { viewport } )
+	buttonBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/card.spec.js
+++ b/cypress/integration/v2/blocks/card.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertContainer,
 } from '~stackable-e2e/helpers'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -63,10 +63,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/card' )
+	cy.addBlock( 'ugb/card' ).as( 'cardBlock' )
+	const cardBlock = __experimentalRegisterBlockSnapshots( 'cardBlock' )
 	cy.openInspector( 'ugb/card', 'Style' )
 
 	cy.collapse( 'General' )
@@ -76,132 +77,13 @@ function styleTab( viewport, desktopOnly ) {
 
 	cy.collapse( 'Container' )
 
-	desktopOnly( () => {
-		cy.adjust( 'Background', {
-			'Color Type': 'single',
-			'Background Color': '#000000',
-			'Background Color Opacity': 0.7,
-		} ).assertComputedStyle( {
-			'.ugb-card__item': {
-				'background-color': 'rgba(0, 0, 0, 0.7)',
-			},
-		} )
-	} )
-
 	cy.setBlockAttribute( {
-		[ `column${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
 		'image1Url': Cypress.env( 'DUMMY_IMAGE_URL' ),
 		'image2Url': Cypress.env( 'DUMMY_IMAGE_URL' ),
 		'image3Url': Cypress.env( 'DUMMY_IMAGE_URL' ),
 	} )
 
-	desktopOnly( () => {
-		cy.adjust( 'Background', {
-			'Background Media Tint Strength': 7,
-			'Fixed Background': true,
-			'Adv. Background Image Settings': {
-				'Image Blend Mode': 'hue',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-card__item': {
-				'background-image': `url("${ Cypress.env( 'DUMMY_IMAGE_URL' ) }")`,
-				'background-attachment': 'fixed',
-				'background-blend-mode': 'hue',
-			},
-			'.ugb-card__item:before': {
-				'opacity': '0.7',
-			},
-		} )
-	} )
-
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Position': {
-				viewport,
-				value: 'center center',
-			},
-			'Image Repeat': {
-				viewport,
-				value: 'repeat-x',
-			},
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 19,
-				unit: '%',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-card__item': {
-			'background-position': '50% 50%',
-			'background-repeat': 'repeat-x',
-			'background-size': '19%',
-		},
-	} )
-
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 23,
-				unit: 'px',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-card__item': {
-			'background-size': '23px',
-		},
-	} )
-
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 8,
-				unit: 'vw',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-card__item': {
-			'background-size': '8vw',
-		},
-	} )
-
-	desktopOnly( () => {
-		cy.adjust( 'Borders', 'solid' )
-		cy.adjust( 'Border Color', '#a12222' )
-		cy.adjust( 'Border Radius', 26 ).assertComputedStyle( {
-			'.ugb-card__item': {
-				'border-style': 'solid',
-				'border-color': '#a12222',
-				'border-radius': '26px',
-			},
-		} )
-		cy.adjust( 'Shadow / Outline', 7 )
-			.assertClassName( '.ugb-card__item', 'ugb--shadow-7' )
-	} )
-
-	cy.adjust( 'Borders', 'dashed' )
-	cy.adjust( 'Border Width', 3, { viewport } ).assertComputedStyle( {
-		'.ugb-card__item': {
-			'border-style': 'dashed',
-			'border-top-width': '3px',
-			'border-bottom-width': '3px',
-			'border-left-width': '3px',
-			'border-right-width': '3px',
-		},
-	} )
+	assertContainer( '.ugb-card__item', { viewport }, 'column%sBackgroundMediaUrl' )
 
 	cy.collapse( 'Image' )
 	// TODO: Image Size assertion
@@ -424,7 +306,7 @@ function styleTab( viewport, desktopOnly ) {
 			'padding-left': '3em',
 		},
 	} )
-	cy.adjust( 'Paddings', 19, { viewport, unit: 'em' } ).assertComputedStyle( {
+	cy.adjust( 'Paddings', 19, { viewport, unit: '%' } ).assertComputedStyle( {
 		'.ugb-card__content': {
 			'padding-top': '19%',
 			'padding-bottom': '19%',
@@ -456,4 +338,5 @@ function styleTab( viewport, desktopOnly ) {
 	// Test Block Background
 	assertBlockBackground( '.ugb-card', { viewport } )
 	assertSeparators( { viewport } )
+	cardBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/card.spec.js
+++ b/cypress/integration/v2/blocks/card.spec.js
@@ -63,11 +63,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/card' ).as( 'cardBlock' )
-	const cardBlock = __experimentalRegisterBlockSnapshots( 'cardBlock' )
+	const cardBlock = registerBlockSnapshots( 'cardBlock' )
 	cy.openInspector( 'ugb/card', 'Style' )
 
 	cy.collapse( 'General' )

--- a/cypress/integration/v2/blocks/container.spec.js
+++ b/cypress/integration/v2/blocks/container.spec.js
@@ -3,7 +3,7 @@
  */
 import { blocks } from '~stackable-e2e/config'
 import {
-	assertAligns, assertBlockBackground, assertBlockExist, assertSeparators, blockErrorTest, switchLayouts, registerTests, responsiveAssertHelper,
+	assertAligns, assertBlockBackground, assertBlockExist, assertSeparators, blockErrorTest, switchLayouts, registerTests, responsiveAssertHelper, assertContainer,
 } from '~stackable-e2e/helpers'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -50,10 +50,11 @@ function switchLayout() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/container' )
+	cy.addBlock( 'ugb/container' ).as( 'containerBlock' )
+	const containerBlock = registerBlockSnapshots( 'containerBlock' )
 	cy.openInspector( 'ugb/container', 'Style' )
 
 	// General Tab
@@ -126,112 +127,7 @@ function styleTab( viewport, desktopOnly ) {
 	// Container Tab
 	cy.collapse( 'Container' )
 
-	// Background Tab
-	desktopOnly( () => {
-		// Test Single
-		cy.adjust( 'Background', {
-			'Color Type': 'single',
-			'Background Color': '#000000',
-			'Background Color Opacity': 0.7,
-		} ).assertComputedStyle( {
-			'.ugb-container__wrapper': {
-				'background-color': 'rgba(0, 0, 0, 0.7)',
-			},
-		} )
-
-		// Test Gradient
-		cy.adjust( 'Background', {
-			'Color Type': 'gradient',
-			'Background Color #1': '#ff5c5c',
-			'Background Color #2': '#7bff5a',
-			'Adv. Gradient Color Settings': {
-				'Gradient Direction (degrees)': 160,
-				'Color 1 Location': 28,
-				'Color 2 Location': 75,
-				'Background Gradient Blend Mode': 'hue',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-container__wrapper:before': {
-				'background-image': 'linear-gradient(160deg, #ff5c5c 28%, #7bff5a 75%)',
-				'mix-blend-mode': 'hue',
-			},
-			'.ugb-container__wrapper': {
-				'background-color': '#ff5c5c',
-			},
-		} )
-	} )
-
-	// Test Image
-	cy.setBlockAttribute( {
-		[ `column${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
-	} )
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Position': {
-				viewport,
-				value: 'top right',
-			},
-			'Image Repeat': {
-				viewport,
-				value: 'repeat-x',
-			},
-			'Image Size': {
-				viewport,
-				value: 'cover',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-container__wrapper': {
-			'background-position': '100% 0%',
-			'background-repeat': 'repeat-x',
-			'background-size': 'cover',
-		},
-	} )
-
-	desktopOnly( () => {
-		// Test non-responsive image settings
-		cy.adjust( 'Background', {
-			'Background Media Tint Strength': 7,
-			'Fixed Background': true,
-			'Adv. Background Image Settings': {
-				'Image Blend Mode': 'exclusion',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-container__wrapper': {
-				'background-attachment': 'fixed',
-				'background-blend-mode': 'exclusion',
-			},
-			'.ugb-container__wrapper:before': {
-				'opacity': '0.7',
-			},
-		} )
-	} )
-
-	// Test Borders and Shadow Outlines
-	desktopOnly( () => {
-		cy.adjust( 'Borders', 'solid' )
-		cy.adjust( 'Border Color', '#a12222' )
-		cy.adjust( 'Border Radius', 26 ).assertComputedStyle( {
-			'.ugb-container__wrapper': {
-				'border-style': 'solid',
-				'border-color': '#a12222',
-				'border-radius': '26px',
-			},
-		} )
-		cy.adjust( 'Shadow / Outline', 5 )
-			.assertClassName( '.ugb-container__wrapper', 'ugb--shadow-5' )
-	} )
-
-	cy.adjust( 'Borders', 'dashed' )
-	cy.adjust( 'Border Width', 4, { viewport } ).assertComputedStyle( {
-		'.ugb-container__wrapper': {
-			'border-style': 'dashed',
-			'border-top-width': '4px',
-			'border-bottom-width': '4px',
-			'border-left-width': '4px',
-			'border-right-width': '4px',
-		},
-	} )
+	assertContainer( '.ugb-container__wrapper', { viewport }, 'column%sBackgroundMediaUrl' )
 
 	// Spacing Tab
 	cy.collapse( 'Spacing' )
@@ -298,4 +194,5 @@ function styleTab( viewport, desktopOnly ) {
 	cy.selectBlock( 'ugb/container' )
 	assertBlockBackground( '.ugb-container', { viewport } )
 	assertSeparators( { viewport } )
+	containerBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/count-up.spec.js
+++ b/cypress/integration/v2/blocks/count-up.spec.js
@@ -53,10 +53,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/count-up' )
+	cy.addBlock( 'ugb/count-up' ).as( 'countUpBlock' )
+	const countUpBlock = registerBlockSnapshots( 'countUpBlock' )
 	cy.openInspector( 'ugb/count-up', 'Style' )
 
 	cy.collapse( 'General' )
@@ -64,6 +65,7 @@ function styleTab( viewport, desktopOnly ) {
 		cy.adjust( 'Columns', 4 )
 			.assertClassName( '.ugb-count-up', 'ugb-countup--columns-4' )
 	} )
+
 	assertAligns( 'Align', '.ugb-inner-block', { viewport } )
 
 	cy.collapse( 'Icon' )
@@ -71,8 +73,6 @@ function styleTab( viewport, desktopOnly ) {
 	cy.waitFA()
 	cy.adjust( 'Icon #1', 'info' )
 	cy.adjust( 'Icon #2', 'info' )
-	cy.adjust( 'Icon #3', 'info' )
-	cy.adjust( 'Icon #4', 'info' )
 
 	desktopOnly( () => {
 		cy.adjust( 'Icon Color Type', 'single' )
@@ -262,4 +262,5 @@ function styleTab( viewport, desktopOnly ) {
 	assertBlockTitleDescription( { viewport } )
 	assertBlockBackground( '.ugb-count-up', { viewport } )
 	assertSeparators( { viewport } )
+	countUpBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/cta.spec.js
+++ b/cypress/integration/v2/blocks/cta.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertBlockBackground, assertSeparators, assertTypography,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertBlockBackground, assertSeparators, assertTypography, assertContainer,
 } from '~stackable-e2e/helpers'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -81,10 +81,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/cta' )
+	cy.addBlock( 'ugb/cta' ).as( 'ctaBlock' )
+	const ctaBlock = registerBlockSnapshots( 'ctaBlock' )
 	cy.openInspector( 'ugb/cta', 'Style' )
 
 	// Test General options
@@ -93,112 +94,7 @@ function styleTab( viewport, desktopOnly ) {
 
 	// Test Container options
 	cy.collapse( 'Container' )
-
-	desktopOnly( () => {
-		cy.adjust( 'Background', {
-			'Color Type': 'single',
-			'Background Color': '#000000',
-			'Background Color Opacity': 0.7,
-		} ).assertComputedStyle( {
-			'.ugb-cta__item': {
-				'background-color': 'rgba(0, 0, 0, 0.7)',
-			},
-		} )
-		cy.setBlockAttribute( {
-			'columnBackgroundMediaUrl': Cypress.env( 'DUMMY_IMAGE_URL' ),
-		} )
-		cy.adjust( 'Background', {
-			'Background Media Tint Strength': 7,
-			'Fixed Background': true,
-		} ).assertComputedStyle( {
-			'.ugb-cta__item': {
-				'background-image': `url("${ Cypress.env( 'DUMMY_IMAGE_URL' ) }")`,
-				'background-attachment': 'fixed',
-			},
-			'.ugb-cta__item:before': {
-				'opacity': '0.7',
-			},
-		} )
-		cy.adjust( 'Background', {
-			'Adv. Background Image Settings': {
-				'Image Blend Mode': 'hue',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-cta__item': {
-				'background-blend-mode': 'hue',
-			},
-		} )
-	} )
-
-	const mobileTabletViewports = [ 'Tablet', 'Mobile' ]
-	cy.setBlockAttribute( { [ `column${ mobileTabletViewports.some( _viewport => _viewport === viewport ) ? viewport : '' }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ) } )
-
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Position': {
-				viewport,
-				value: 'top left',
-			},
-			'Image Repeat': {
-				viewport,
-				value: 'no-repeat',
-			},
-			'Image Size': {
-				viewport,
-				value: 'cover',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-cta__item': {
-			'background-size': 'cover',
-		},
-	} )
-
-	desktopOnly( () => {
-		// Test Container Gradient
-		cy.adjust( 'Background', {
-			'Color Type': 'gradient',
-			'Background Color #1': '#000000',
-			'Background Color #2': '#ff0000',
-			'Adv. Gradient Color Settings': {
-				'Gradient Direction (degrees)': '160deg',
-				'Color 1 Location': '30%',
-				'Color 2 Location': '83%',
-				'Background Gradient Blend Mode': 'difference',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-cta__item:before': {
-				'background-image': 'linear-gradient(160deg, #000000 30%, #ff0000 83%)',
-				'mix-blend-mode': 'difference',
-			},
-		} )
-
-		cy.adjust( 'Borders', 'solid' )
-		cy.adjust( 'Border Width', 4 )
-		cy.adjust( 'Border Color', '#ff0000' )
-		cy.adjust( 'Border Radius', 26 ).assertComputedStyle( {
-			'.ugb-cta__item': {
-				'border-top-left-radius': '26px',
-				'border-top-right-radius': '26px',
-				'border-bottom-left-radius': '26px',
-				'border-bottom-right-radius': '26px',
-				'border-top-width': '4px',
-				'border-right-width': '4px',
-				'border-bottom-width': '4px',
-				'border-left-width': '4px',
-				'border-top-style': 'solid',
-				'border-right-style': 'solid',
-				'border-bottom-style': 'solid',
-				'border-left-style': 'solid',
-				'border-top-color': '#ff0000',
-				'border-right-color': '#ff0000',
-				'border-bottom-color': '#ff0000',
-				'border-left-color': '#ff0000',
-			},
-		} )
-		cy.adjust( 'Shadow / Outline', 2 )
-			.assertClassName( '.ugb-cta__item', 'ugb--shadow-2' )
-	} )
+	assertContainer( '.ugb-cta__item', { viewport }, 'column%sBackgroundMediaUrl' )
 
 	// Test Spacing options
 	cy.collapse( 'Spacing' )
@@ -380,4 +276,5 @@ function styleTab( viewport, desktopOnly ) {
 	assertBlockBackground( '.ugb-cta', { viewport } )
 
 	assertSeparators( { viewport } )
+	ctaBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/divider.spec.js
+++ b/cypress/integration/v2/blocks/divider.spec.js
@@ -33,10 +33,11 @@ function switchLayout() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/divider' )
+	cy.addBlock( 'ugb/divider' ).as( 'dividerBlock' )
+	const dividerBlock = registerBlockSnapshots( 'dividerBlock' )
 	cy.openInspector( 'ugb/divider', 'Style' )
 
 	// Test General options
@@ -61,4 +62,5 @@ function styleTab( viewport, desktopOnly ) {
 	} )
 
 	assertAligns( 'Align', '.ugb-inner-block', { viewport } )
+	dividerBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/expand.spec.js
+++ b/cypress/integration/v2/blocks/expand.spec.js
@@ -23,10 +23,11 @@ function blockError() {
 	it( 'should not trigger block error when refreshing the page', blockErrorTest( 'ugb/expand' ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/expand' )
+	cy.addBlock( 'ugb/expand' ).as( 'expandBlock' )
+	const expandBlock = registerBlockSnapshots( 'expandBlock' )
 	cy.openInspector( 'ugb/expand', 'Style' )
 
 	// Test General options
@@ -87,5 +88,6 @@ function styleTab( viewport, desktopOnly ) {
 			'margin-bottom': '39px',
 		},
 	} )
+	expandBlock.assertFrontendStyles()
 }
 

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertAligns, responsiveAssertHelper, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertAligns, responsiveAssertHelper, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertContainer,
 } from '~stackable-e2e/helpers'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -72,10 +72,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/feature-grid' )
+	cy.addBlock( 'ugb/feature-grid' ).as( 'featureGridBlock' )
+	const featureGridBlock = __experimentalRegisterBlockSnapshots( 'featureGridBlock' )
 
 	cy.openInspector( 'ugb/feature-grid', 'Style' )
 
@@ -86,86 +87,13 @@ function styleTab( viewport, desktopOnly ) {
 
 	cy.collapse( 'Container' )
 	cy.setBlockAttribute( {
-		[ `column${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
 		'image1Url': Cypress.env( 'DUMMY_IMAGE_URL' ),
 		'image2Url': Cypress.env( 'DUMMY_IMAGE_URL' ),
 		'image3Url': Cypress.env( 'DUMMY_IMAGE_URL' ),
 		'image4Url': Cypress.env( 'DUMMY_IMAGE_URL' ),
 	} )
-	desktopOnly( () => {
-		cy.adjust( 'Background', {
-			'Color Type': 'gradient',
-			'Background Color #1': '#ff5c5c',
-			'Background Color #2': '#7bff5a',
-			'Adv. Gradient Color Settings': {
-				'Gradient Direction (degrees)': 160,
-				'Color 1 Location': 28,
-				'Color 2 Location': 75,
-				'Background Gradient Blend Mode': 'hue',
-			},
-			'Background Media Tint Strength': 6,
-			'Fixed Background': true,
-			'Adv. Background Image Settings': {
-				'Image Blend Mode': 'exclusion',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-feature-grid__item:before': {
-				'background-image': 'linear-gradient(160deg, #ff5c5c 28%, #7bff5a 75%)',
-				'opacity': '0.6',
-				'mix-blend-mode': 'hue',
-			},
-			'.ugb-feature-grid__item': {
-				'background-color': '#ff5c5c',
-				'background-attachment': 'fixed',
-				'background-blend-mode': 'exclusion',
-			},
-		} )
-	} )
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Position': {
-				viewport,
-				value: 'center center',
-			},
-			'Image Repeat': {
-				viewport,
-				value: 'repeat-x',
-			},
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 19,
-				unit: '%',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-feature-grid__item': {
-			'background-position': '50% 50%',
-			'background-repeat': 'repeat-x',
-			'background-size': '19%',
-		},
-	} )
-	desktopOnly( () => {
-		cy.adjust( 'Borders', 'solid' )
-		cy.adjust( 'Border Width', 4 )
-		cy.adjust( 'Border Color', '#a12222' )
-		cy.adjust( 'Border Radius', 26 ).assertComputedStyle( {
-			'.ugb-feature-grid__item': {
-				'border-style': 'solid',
-				'border-top-width': '4px',
-				'border-bottom-width': '4px',
-				'border-left-width': '4px',
-				'border-right-width': '4px',
-				'border-color': '#a12222',
-				'border-radius': '26px',
-			},
-		} )
-		cy.adjust( 'Shadow / Outline', 7 )
-			.assertClassName( '.ugb-feature-grid__item', 'ugb--shadow-7' )
-	} )
+
+	assertContainer( '.ugb-feature-grid__item', { viewport }, 'column%sBackgroundMediaUrl' )
 	cy.collapse( 'Image' )
 	cy.adjust( 'Image Width', 29, { viewport } ).assertComputedStyle( {
 		'.ugb-img': {
@@ -369,5 +297,6 @@ function styleTab( viewport, desktopOnly ) {
 	assertBlockTitleDescription( { viewport } )
 	assertBlockBackground( '.ugb-feature-grid', { viewport } )
 	assertSeparators( { viewport } )
+	featureGridBlock.assertFrontendStyles()
 }
 

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -72,11 +72,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly, __experimentalRegisterBlockSnapshots ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/feature-grid' ).as( 'featureGridBlock' )
-	const featureGridBlock = __experimentalRegisterBlockSnapshots( 'featureGridBlock' )
+	const featureGridBlock = registerBlockSnapshots( 'featureGridBlock' )
 
 	cy.openInspector( 'ugb/feature-grid', 'Style' )
 

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertAligns, assertBlockBackground, assertSeparators, responsiveAssertHelper, assertTypography,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertAligns, assertBlockBackground, assertSeparators, responsiveAssertHelper, assertTypography, assertContainer,
 } from '~stackable-e2e/helpers'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -75,11 +75,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/header' )
-
+	cy.addBlock( 'ugb/header' ).as( 'headerBlock' )
+	const headerBlock = registerBlockSnapshots( 'headerBlock' )
 	cy.openInspector( 'ugb/header', 'Style' )
 
 	cy.collapse( 'General' )
@@ -90,84 +90,7 @@ function styleTab( viewport, desktopOnly ) {
 	assertAligns( 'Align', '.ugb-inner-block', { viewport } )
 
 	cy.collapse( 'Container' )
-	cy.setBlockAttribute( {
-		[ `column${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
-	} )
-	desktopOnly( () => {
-		cy.adjust( 'Background', {
-			'Color Type': 'gradient',
-			'Background Color #1': '#ff5c5c',
-			'Background Color #2': '#7bff5a',
-			'Adv. Gradient Color Settings': {
-				'Gradient Direction (degrees)': 160,
-				'Color 1 Location': 28,
-				'Color 2 Location': 75,
-				'Background Gradient Blend Mode': 'hue',
-			},
-			'Background Media Tint Strength': 6,
-			'Fixed Background': true,
-			'Adv. Background Image Settings': {
-				'Image Blend Mode': 'exclusion',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-header__item:before': {
-				'background-image': 'linear-gradient(160deg, #ff5c5c 28%, #7bff5a 75%)',
-				'opacity': '0.6',
-				'mix-blend-mode': 'hue',
-			},
-			'.ugb-header__item': {
-				'background-color': '#ff5c5c',
-				'background-attachment': 'fixed',
-				'background-blend-mode': 'exclusion',
-			},
-		} )
-	} )
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Position': {
-				viewport,
-				value: 'center center',
-			},
-			'Image Repeat': {
-				viewport,
-				value: 'repeat-x',
-			},
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 19,
-				unit: '%',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-header__item': {
-			'background-position': '50% 50%',
-			'background-repeat': 'repeat-x',
-			'background-size': '19%',
-		},
-	} )
-
-	desktopOnly( () => {
-		cy.adjust( 'Borders', 'solid' )
-		cy.adjust( 'Border Width', 4 )
-		cy.adjust( 'Border Color', '#a12222' )
-		cy.adjust( 'Border Radius', 26 ).assertComputedStyle( {
-			'.ugb-header__item': {
-				'border-style': 'solid',
-				'border-top-width': '4px',
-				'border-bottom-width': '4px',
-				'border-left-width': '4px',
-				'border-right-width': '4px',
-				'border-color': '#a12222',
-				'border-radius': '26px',
-			},
-		} )
-		cy.adjust( 'Shadow / Outline', 7 )
-			.assertClassName( '.ugb-header__item', 'ugb--shadow-7' )
-	} )
+	assertContainer( '.ugb-header__item', { viewport }, 'column%sBackgroundMediaUrl' )
 
 	cy.collapse( 'Spacing' )
 	desktopOnly( () => {
@@ -481,4 +404,5 @@ function styleTab( viewport, desktopOnly ) {
 
 	assertBlockBackground( '.ugb-header', { viewport } )
 	assertSeparators( { viewport } )
+	headerBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/heading.spec.js
+++ b/cypress/integration/v2/blocks/heading.spec.js
@@ -24,10 +24,11 @@ function blockError() {
 	it( 'should not trigger block error when refreshing the page', blockErrorTest( 'ugb/heading' ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/heading' )
+	cy.addBlock( 'ugb/heading' ).as( 'headingBlock' )
+	const headingBlock = registerBlockSnapshots( 'headingBlock' )
 	cy.openInspector( 'ugb/heading', 'Style' )
 
 	// Test General Alignment
@@ -161,4 +162,5 @@ function styleTab( viewport, desktopOnly ) {
 			'margin-bottom': '12px',
 		},
 	} )
+	headingBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -52,12 +52,12 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
 
-	cy.addBlock( 'ugb/icon-list' )
-
+	cy.addBlock( 'ugb/icon-list' ).as( 'iconListBlock' )
+	const iconListBlock = registerBlockSnapshots( 'iconListBlock' )
 	cy.openInspector( 'ugb/icon-list', 'Style' )
 	cy.collapse( 'General' )
 	cy.adjust( 'Columns', 4, { viewport } ).assertComputedStyle( {
@@ -114,4 +114,5 @@ function styleTab( viewport, desktopOnly ) {
 	assertBlockTitleDescription( { viewport } )
 	assertBlockBackground( '.ugb-icon-list', { viewport } )
 	assertSeparators( { viewport } )
+	iconListBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/icon.spec.js
+++ b/cypress/integration/v2/blocks/icon.spec.js
@@ -34,11 +34,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/icon' )
-
+	cy.addBlock( 'ugb/icon' ).as( 'iconBlock' )
+	const iconBlock = registerBlockSnapshots( 'iconBlock' )
 	cy.openInspector( 'ugb/icon', 'Style' )
 
 	// Test General options
@@ -201,5 +201,6 @@ function styleTab( viewport, desktopOnly ) {
 
 	// Test Top and Bottom Separator
 	assertSeparators( { viewport } )
+	iconBlock.assertFrontendStyles()
 }
 

--- a/cypress/integration/v2/blocks/notification.spec.js
+++ b/cypress/integration/v2/blocks/notification.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockBackground,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockBackground, assertContainer,
 } from '~stackable-e2e/helpers'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -49,10 +49,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/notification' )
+	cy.addBlock( 'ugb/notification' ).as( 'notificationBlock' )
+	const notificationBlock = registerBlockSnapshots( 'notificationBlock' )
 	cy.openInspector( 'ugb/notification', 'Style' )
 
 	// Test General options
@@ -73,123 +74,7 @@ function styleTab( viewport, desktopOnly ) {
 
 	// Test Container options
 	cy.collapse( 'Container' )
-	cy.setBlockAttribute( {
-		[ `column${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
-	} )
-	desktopOnly( () => {
-		cy.adjust( 'Background', {
-			'Color Type': 'gradient',
-			'Background Color #1': '#ff5c5c',
-			'Background Color #2': '#7bff5a',
-			'Adv. Gradient Color Settings': {
-				'Gradient Direction (degrees)': 160,
-				'Color 1 Location': 28,
-				'Color 2 Location': 75,
-				'Background Gradient Blend Mode': 'multiply',
-			},
-			'Background Media Tint Strength': 6,
-			'Fixed Background': true,
-			'Adv. Background Image Settings': {
-				'Image Blend Mode': 'exclusion',
-			},
-		} ).assertComputedStyle( {
-			'.ugb-notification__item:before': {
-				'background-image': 'linear-gradient(160deg, #ff5c5c 28%, #7bff5a 75%)',
-				'opacity': '0.6',
-				'mix-blend-mode': 'multiply',
-			},
-			'.ugb-notification__item': {
-				'background-color': '#ff5c5c',
-				'background-attachment': 'fixed',
-				'background-blend-mode': 'exclusion',
-			},
-		} )
-	} )
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Position': {
-				viewport,
-				value: 'center center',
-			},
-			'Image Repeat': {
-				viewport,
-				value: 'repeat-x',
-			},
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 19,
-				unit: '%',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-notification__item': {
-			'background-position': '50% 50%',
-			'background-repeat': 'repeat-x',
-			'background-size': '19%',
-		},
-	} )
-
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 160,
-				unit: 'px',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-notification__item': {
-			'background-size': '160px',
-		},
-	} )
-
-	cy.adjust( 'Background', {
-		'Adv. Background Image Settings': {
-			'Image Size': {
-				viewport,
-				value: 'custom',
-			},
-			'Custom Size': {
-				viewport,
-				value: 8,
-				unit: 'vw',
-			},
-		},
-	} ).assertComputedStyle( {
-		'.ugb-notification__item': {
-			'background-size': '8vw',
-		},
-	} )
-
-	cy.adjust( 'Borders', 'dashed' )
-	desktopOnly( () => {
-		cy.adjust( 'Border Color', '#3f3f3f' )
-		cy.adjust( 'Border Radius', 23 ).assertComputedStyle( {
-			'.ugb-notification__item': {
-				'border-color': '#3f3f3f',
-				'border-radius': '23px',
-			},
-		} )
-		cy.adjust( 'Shadow / Outline', 7 )
-			.assertClassName( '.ugb-notification__item', 'ugb--shadow-7' )
-	} )
-	cy.adjust( 'Border Width', 23, { viewport } ).assertComputedStyle( {
-		'.ugb-notification__item': {
-			'border-style': 'dashed',
-			'border-top-width': '23px',
-			'border-right-width': '23px',
-			'border-bottom-width': '23px',
-			'border-left-width': '23px',
-		},
-	} )
+	assertContainer( '.ugb-notification__item', { viewport }, 'column%sBackgroundMediaUrl' )
 
 	// Test Dismissible
 	cy.collapse( 'Dismissible' )
@@ -442,4 +327,5 @@ function styleTab( viewport, desktopOnly ) {
 
 	// Test Block Background
 	assertBlockBackground( '.ugb-notification', { viewport } )
+	notificationBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/separator.spec.js
+++ b/cypress/integration/v2/blocks/separator.spec.js
@@ -41,10 +41,11 @@ function switchLayout() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/separator' )
+	cy.addBlock( 'ugb/separator' ).as( 'separatorBlock' )
+	const separatorBlock = registerBlockSnapshots( 'separatorBlock' )
 	cy.openInspector( 'ugb/separator', 'Style' )
 
 	desktopOnly( () => {
@@ -264,4 +265,5 @@ function styleTab( viewport, desktopOnly ) {
 			},
 		} )
 	} )
+	separatorBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/spacer.spec.js
+++ b/cypress/integration/v2/blocks/spacer.spec.js
@@ -27,10 +27,11 @@ function blockError() {
 	it( 'should not trigger block error when refreshing the page', blockErrorTest( 'ugb/spacer' ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/spacer' )
+	cy.addBlock( 'ugb/spacer' ).as( 'spacerBlock' )
+	const spacerBlock = registerBlockSnapshots( 'spacerBlock' )
 	cy.openInspector( 'ugb/spacer', 'Style' )
 
 	cy.collapse( 'General' )
@@ -156,4 +157,5 @@ function styleTab( viewport, desktopOnly ) {
 	} )
 
 	assertSeparators( { viewport } )
+	spacerBlock.assertFrontendStyles()
 }

--- a/cypress/integration/v2/blocks/text.spec.js
+++ b/cypress/integration/v2/blocks/text.spec.js
@@ -55,10 +55,11 @@ function switchDesign() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly ) {
+function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cy.setupWP()
 	cy.newPage()
-	cy.addBlock( 'ugb/text' )
+	cy.addBlock( 'ugb/text' ).as( 'textBlock' )
+	const textBlock = registerBlockSnapshots( 'textBlock' )
 	cy.openInspector( 'ugb/text', 'Style' )
 
 	// Test General options
@@ -205,4 +206,5 @@ function styleTab( viewport, desktopOnly ) {
 
 	// Test Top and Bottom Separator
 	assertSeparators( { viewport } )
+	textBlock.assertFrontendStyles()
 }

--- a/cypress/support/advanced.js
+++ b/cypress/support/advanced.js
@@ -25,6 +25,7 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 		enablePaddingRight = true,
 		enablePaddingBottom = true,
 		enablePaddingLeft = true,
+		__experimentalBlockSnapshots = false,
 	} = options
 
 	const MAIN_SELECTOR = '.ugb-main-block'
@@ -50,7 +51,7 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 			.then( $panel => {
 				if ( $panel.text().includes( adjustName ) ) {
 					if ( args.length ) {
-						cy.adjust( adjustName, value, options )[ assertionFunc ]( ...args )
+						cy.adjust( adjustName, value, options )[ assertionFunc ]( ... [ ...args, { __experimentalBlockSnapshots } ] )
 					} else {
 						cy.adjust( adjustName, value, options )
 					}

--- a/cypress/support/advanced.js
+++ b/cypress/support/advanced.js
@@ -25,7 +25,6 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 		enablePaddingRight = true,
 		enablePaddingBottom = true,
 		enablePaddingLeft = true,
-		__experimentalBlockSnapshots = false,
 	} = options
 
 	const MAIN_SELECTOR = '.ugb-main-block'
@@ -51,7 +50,7 @@ export const assertAdvancedTab = ( name, options = {}, desktopCallback = () => {
 			.then( $panel => {
 				if ( $panel.text().includes( adjustName ) ) {
 					if ( args.length ) {
-						cy.adjust( adjustName, value, options )[ assertionFunc ]( ... [ ...args, { __experimentalBlockSnapshots } ] )
+						cy.adjust( adjustName, value, options )[ assertionFunc ]( ... args )
 					} else {
 						cy.adjust( adjustName, value, options )
 					}

--- a/cypress/support/blockSnapshots.js
+++ b/cypress/support/blockSnapshots.js
@@ -9,7 +9,7 @@
  * Internal dependencies
  */
 import {
-	createElementFromHTMLString, parseClassList,
+	createElementFromHTMLString,
 } from './util'
 import { _assertComputedStyle } from './commands/styles'
 import config from '../../cypress.json'
@@ -101,7 +101,7 @@ class BlockSnapshots {
 							// Create a DOMElement based on the HTML string.
 							const blockElement = createElementFromHTMLString( htmlContent )
 							// Get the class selector.
-							const classList = parseClassList( Array.from( blockElement.classList ).join( ' ' ) )
+							const classList = Array.from( blockElement.classList ).map( _class => `.${ _class }` ).join( '' )
 							// Remove all blocks inside .entry-content.
 							doc.querySelector( '.entry-content' ).innerHTML = ''
 

--- a/cypress/support/blockSnapshots.js
+++ b/cypress/support/blockSnapshots.js
@@ -18,7 +18,7 @@ import config from '../../cypress.json'
  * External dependencies
  */
 import {
-	first, keys, last,
+	first, keys, last, isBoolean,
 } from 'lodash'
 
 class BlockSnapshots {
@@ -159,11 +159,13 @@ export const registerBlockSnapshots = alias => {
 	Cypress.Commands.overwrite( 'assertComputedStyle', ( originalFn, ...args ) => {
 		function modifiedFn( ...passedArgs ) {
 			cy.getPreviewMode().then( viewport => {
-				blockSnapshots.createContentSnapshot()
 				const options = passedArgs.pop()
 				options.blockSnapshots = blockSnapshots
+				if ( options.assertFrontend === undefined || ( isBoolean( options.assertFrontend ) && options.assertFrontend ) ) {
+					blockSnapshots.stubStyles( passedArgs[ 1 ], options.viewportFrontend || viewport )
+					blockSnapshots.createContentSnapshot()
+				}
 				options.assertFrontend = false
-				blockSnapshots.stubStyles( passedArgs[ 1 ], options.viewportFrontend || viewport )
 				originalFn( ...[ ...passedArgs, options ] )
 			} )
 		}

--- a/cypress/support/blockSnapshots.js
+++ b/cypress/support/blockSnapshots.js
@@ -1,8 +1,23 @@
 /**
- * `wp.blocks.getBlockContent` can be used to generate
- * save block HTML content. With this, we can overwrite
- *`getComputedStyle` to stub all generated HTML contents and
- * CSS objects for future assertions.
+ * Block Snapshots
+ * `wp.blocks.getBlockContent` can be used to generate block HTML content. With this,
+ * we can overwrite `getComputedStyle` to stub all generated HTML contents and CSS objects for future assertions.
+ *
+ * Usage:
+ * function desktopStyles( viewport, desktopOnly, registerBlockSnapshots ) {
+ *   cy.setupWP()
+ *   cy.newPage()
+ *   cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )
+ *   const accordionBlock = registerBlockSnapshots( 'accordionBlock' )
+ *
+ *   // More tests...
+ *   // assertComputedStyle will no longer assert the frontend
+ *   // every call. Instead, block snapshots will be stubbed and
+ *   // can be enqueued before the end of the test.
+ *
+ *   // Enqueue all block snapshots and assert frontend styles.
+ *   accordionBlock.assertFrontendStyles()
+ * }
  */
 
 /**

--- a/cypress/support/blockSnapshots.js
+++ b/cypress/support/blockSnapshots.js
@@ -1,8 +1,8 @@
 /**
  * `wp.blocks.getBlockContent` can be used to generate
- * save block html content. With this, we can overwrite
- *``getComputedStyle` to stub all generated HTML content and
- * css object for future assertions.
+ * save block HTML content. With this, we can overwrite
+ *`getComputedStyle` to stub all generated HTML contents and
+ * CSS objects for future assertions.
  */
 
 /**

--- a/cypress/support/blockSnapshots.js
+++ b/cypress/support/blockSnapshots.js
@@ -1,0 +1,146 @@
+/**
+ * Internal dependencies
+ */
+import { createElementFromHTMLString, parseClassList } from './util'
+import { _assertComputedStyle } from './commands/styles'
+import config from '../../cypress.json'
+
+/**
+ * External dependencies
+ */
+import {
+	first, keys, last,
+} from 'lodash'
+
+class BlockSnapshots {
+	constructor() {
+		// Set Cypress Alias
+		this.alias = null
+	}
+
+	registerAlias( alias ) {
+		this.alias = alias
+		cy.wrap( [] ).as( `${ alias }.contentSnapshots` )
+		cy.wrap( [] ).as( `${ alias }.stubbedStyles` )
+	}
+
+	createContentSnapshot() {
+		const self = this
+		cy.wp().then( wp => {
+			cy.get( `@${ self.alias }` ).then( _block => {
+				const block = wp.data.select( 'core/block-editor' ).getBlock( _block.clientId )
+				const blockContent = wp.blocks.getBlockContent( block )
+				cy.get( `@${ self.alias }.contentSnapshots` ).then( $snapShots => {
+					cy.wrap( [ ...$snapShots, blockContent ] ).as( `${ self.alias }.contentSnapshots` )
+				} )
+			} )
+		} )
+	}
+
+	stubStyles( style, viewport ) {
+		const self = this
+		cy.get( `@${ self.alias }.stubbedStyles` ).then( $stubbedStyles => {
+			$stubbedStyles.push( { style, viewport } )
+			cy.wrap( $stubbedStyles ).as( `${ self.alias }.stubbedStyles` ).then( () => {
+			} )
+		} )
+	}
+
+	assertFrontendStyles() {
+		const self = this
+		cy.get( `@${ self.alias }.stubbedStyles` ).then( $stubbedStyles => {
+			cy.get( `@${ self.alias }.contentSnapshots` ).then( $contentSnapshots => {
+				const combinedStubbed = $contentSnapshots.map( ( htmlContent, index ) => {
+					return {
+						htmlContent,
+						viewport: $stubbedStyles[ index ].viewport,
+						style: $stubbedStyles[ index ].style,
+					}
+				} )
+
+				cy.publish()
+				cy.getPostUrls().then( ( { previewUrl } ) => {
+					cy.visit( previewUrl )
+					combinedStubbed.forEach( combinedStubbedContent => {
+						cy.document().then( doc => {
+							const {
+								viewport, htmlContent, style,
+							} = combinedStubbedContent
+
+							const blockElement = createElementFromHTMLString( htmlContent )
+							const classList = parseClassList( Array.from( blockElement.classList ).join( ' ' ) )
+							doc.querySelector( '.entry-content' ).innerHTML = ''
+
+							if ( viewport !== 'Desktop' ) {
+								cy.viewport( config[ `viewport${ viewport }Width` ] || config.viewportWidth, config.viewportHeight )
+							}
+
+							doc.querySelector( '.entry-content' ).appendChild( blockElement )
+
+							keys( style ).forEach( _selector => {
+								const selector = _selector.split( ':' )
+								const selectorWithSpace = first( selector ).split( ' ' )
+								const [ , ...restOfTheSelectors ] = [ ...selectorWithSpace ]
+
+								const documentSelector = `${ classList }${ first( selectorWithSpace ).match( /\./ )
+									?	( classList.match( first( selectorWithSpace ) )
+										? ` ${ restOfTheSelectors.join( ' ' ) }`
+										: ` ${ first( selector ) }` )
+									: ` ${ first( selector ) }` }`.trim()
+
+								_assertComputedStyle(
+									documentSelector,
+									selector.length && last( selector ),
+									style[ _selector ],
+									'Frontend',
+									viewport )
+							} )
+
+							cy.viewport( config.viewportWidth, config.viewportHeight )
+						} )
+					} )
+				} )
+			} )
+		} )
+	}
+}
+
+export const registerBlockSnapshots = alias => {
+	const blockSnapshot = new BlockSnapshots()
+	blockSnapshot.registerAlias( alias )
+
+	const overwriteAssertionCommands = ( name, argCount ) => {
+		Cypress.Commands.overwrite( name, ( originalFn, ...args ) => {
+			if ( args.length === argCount ) {
+				const options = args.pop()
+				options.__experimentalBlockSnapshots = blockSnapshot
+				return originalFn( ...[ ...args, options ] )
+			}
+			return originalFn( ...[ ...args, { __experimentalBlockSnapshots: blockSnapshot } ] )
+		} )
+	}
+
+	/**
+	 * Overwrite `assertComputedStyle` by passing `__experimentalBlockSnapshots` option
+	 */
+	overwriteAssertionCommands( 'assertComputedStyle', 3 )
+
+	/**
+	 * Overwrite `asserHtmlTag` by passing `__experimentalBlockSnapshots` option
+	 */
+	overwriteAssertionCommands( 'assertHtmlTag', 4 )
+
+	/**
+	 * Overwrite `assertClassName` by passing `__experimentalBlockSnapshots` option
+	 */
+	overwriteAssertionCommands( 'assertClassName', 4 )
+
+	/**
+	 * Overwrite `assertHtmlAttribute` by passing `__experimentalBlockSnapshots` option
+	 */
+	overwriteAssertionCommands( 'assertHtmlAttribute', 4 )
+
+	return blockSnapshot
+}
+
+export default BlockSnapshots

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -11,12 +11,13 @@ Cypress.Commands.overwrite( 'window', modifyLogFunc() )
 Cypress.Commands.overwrite( 'trigger', modifyLogFunc() )
 Cypress.Commands.overwrite( 'parent', modifyLogFunc() )
 Cypress.Commands.overwrite( 'parentsUntil', modifyLogFunc() )
-Cypress.Commands.overwrite( 'invoke', modifyLogFunc( 'first' ) )
+Cypress.Commands.overwrite( 'invoke', modifyLogFunc( { position: 'first' } ) )
 Cypress.Commands.overwrite( 'eq', modifyLogFunc() )
 Cypress.Commands.overwrite( 'first', modifyLogFunc() )
 Cypress.Commands.overwrite( 'wait', modifyLogFunc() )
 Cypress.Commands.overwrite( 'contains', modifyLogFunc() )
 Cypress.Commands.overwrite( 'last', modifyLogFunc() )
+Cypress.Commands.overwrite( 'wrap', modifyLogFunc( { argumentLength: 2 } ) )
 
 /**
  * Register functions to Cypress Commands.
@@ -45,29 +46,10 @@ import './attributes'
  * Internal dependencies
  */
 import {
-	containsRegExp, getBlocksRecursive, dispatchResolver,
+	containsRegExp, getBlocksRecursive, dispatchResolver, modifyLogFunc,
 } from '../util'
 import { last, first } from 'lodash'
 import config from 'root/cypress.json'
-
-/**
- * Function for overwriting log argument.
- *
- * @param {string} position
- */
-function modifyLogFunc( position = 'last' ) {
-	return function( originalFn, ...args ) {
-		const firstOrLast = position === 'last' ? last : first
-		if ( typeof firstOrLast( args ) === 'object' && ! Array.isArray( firstOrLast( args ) ) ) {
-			const options = args[ position === 'last' ? 'pop' : 'shift' ]()
-			options.log = Cypress.env( 'DEBUG' ) === 'true'
-			return position === 'last' ? originalFn( ...args, options ) : originalFn( options, ...args )
-		}
-		return position === 'last'
-			? 			originalFn( ...args, { log: Cypress.env( 'DEBUG' ) === 'true' } )
-			: 			originalFn( { log: Cypress.env( 'DEBUG' ) === 'true' }, ...args )
-	}
-}
 
 /**
  * Command for adding a specific block in the inserter button.

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -88,9 +88,12 @@ export function addBlock( blockName = 'ugb/accordion' ) {
  * Command for selecting a specific block.
  *
  * @param {string} subject
- * @param {string} selector
+ * @param {*} selector
  */
 export function selectBlock( subject, selector ) {
+	if ( selector === '' ) {
+		selector = undefined
+	}
 	cy.wp().then( wp => {
 		cy.get( 'body' ).then( $body => {
 			return new Cypress.Promise( resolve => {
@@ -114,6 +117,14 @@ export function selectBlock( subject, selector ) {
 					wp.data.dispatch( 'core/block-editor' )
 						.selectBlock( willSelectBlock[ selector ].clientId )
 						.then( dispatchResolver( () => resolve( $body.find( `.wp-block[data-block="${ willSelectBlock[ selector ].clientId }"]` ) ) ) )
+				} else if ( typeof selector === 'object' ) {
+					const {
+						clientId,
+					} = selector
+					const resolveCallback = $body.find( `[data-block="${ clientId }"]` )
+					wp.data.dispatch( 'core/block-editor' )
+						.selectBlock( clientId )
+						.then( dispatchResolver( () => resolve( resolveCallback ) ) )
 				} else {
 					wp.data.dispatch( 'core/block-editor' )
 						.selectBlock( ( first( willSelectBlock ) || {} ).clientId )

--- a/cypress/support/commands/index.js
+++ b/cypress/support/commands/index.js
@@ -76,10 +76,10 @@ function modifyLogFunc( position = 'last' ) {
  */
 export function addBlock( blockName = 'ugb/accordion' ) {
 	cy.wp().then( wp => {
-		return new Cypress.Promise( ( resolve, reject ) => {
-			wp.data.dispatch( 'core/editor' ).insertBlock( wp.blocks.createBlock( blockName ) )
-				.then( dispatchResolver( resolve ) )
-				.catch( reject )
+		return new Cypress.Promise( resolve => {
+			const block = wp.blocks.createBlock( blockName )
+			wp.data.dispatch( 'core/editor' ).insertBlock( block )
+				.then( dispatchResolver( () => resolve( last( wp.data.select( 'core/block-editor' ).getBlocks() ) ) ) )
 		} )
 	} )
 }

--- a/cypress/support/commands/styles.js
+++ b/cypress/support/commands/styles.js
@@ -883,7 +883,7 @@ export function _assertComputedStyle( selector, pseudoEl, _cssObject, assertType
 						// Handle conversion of vw to px.
 						if ( expectedValue.match( /vw$/ ) ) {
 							const visualEl = doc.querySelector( '.edit-post-visual-editor' )
-							if ( visualEl && assertType === 'Backend' && viewport !== 'Desktop' ) {
+							if ( visualEl && assertType === 'Editor' && viewport !== 'Desktop' ) {
 								const currEditorWidth = pick( win.getComputedStyle( visualEl ), 'width' ).width
 								return `${ parseFloat( ( parseInt( expectedValue ) ) / 100 * currEditorWidth ) }px`
 							}

--- a/cypress/support/commands/styles.js
+++ b/cypress/support/commands/styles.js
@@ -908,7 +908,7 @@ export function _assertComputedStyle( selector, pseudoEl, _cssObject, assertType
  */
 export function assertComputedStyle( subject, cssObject = {}, options = {} ) {
 	const {
-		__experimentalBlockSnapshots = null,
+		blockSnapshots = null,
 		assertBackend = true,
 		assertFrontend = true,
 		viewportFrontend = false,
@@ -920,9 +920,9 @@ export function assertComputedStyle( subject, cssObject = {}, options = {} ) {
 		( { viewport } ) => {
 			// Stub the block's HTML content and styles. Only do assertions
 			// before the end of responsiveAssertion tests.
-			if ( __experimentalBlockSnapshots && assertFrontend ) {
-				__experimentalBlockSnapshots.createContentSnapshot()
-				__experimentalBlockSnapshots.stubStyles( cssObject, viewportFrontend ? viewportFrontend : viewport )
+			if ( blockSnapshots && assertFrontend ) {
+				blockSnapshots.createContentSnapshot()
+				blockSnapshots.stubStyles( cssObject, viewportFrontend ? viewportFrontend : viewport )
 			}
 
 			if ( assertBackend ) {
@@ -940,7 +940,6 @@ export function assertComputedStyle( subject, cssObject = {}, options = {} ) {
 			}
 		},
 		// Assertion in the frontend.
-		// Frontend callback may soon be deprecated in favor of BlockSnapshots.
 		( {
 			parsedClassList, viewport,
 		} ) => {

--- a/cypress/support/commands/styles.js
+++ b/cypress/support/commands/styles.js
@@ -258,7 +258,7 @@ function colorControl( name, value, options = {} ) {
 			.click( { force: true } )
 
 		cy
-			.get( '.components-popover__content' )
+			.get( '.components-popover__content .components-color-picker' )
 			.find( 'input[type="text"]' )
 			.type( `{selectall}${ value }{enter}`, { force: true } )
 

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -7,7 +7,7 @@ import {
 } from './util'
 import config from '../../cypress.json'
 import { collapse, openSidebar } from './commands/inspector'
-import { registerBlockSnapshots as __experimentalRegisterBlockSnapshots } from './blockSnapshots'
+import { registerBlockSnapshots } from './blockSnapshots'
 
 /**
  * External dependencies
@@ -133,7 +133,7 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 		assertFrontend = true,
 		wait = 0,
 		viewportFrontend = false,
-		__experimentalBlockSnapshots = false,
+		blockSnapshots = false,
 	} = options
 
 	getActiveTab( tab => {
@@ -155,10 +155,10 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 				} )
 
 				/**
-				 * Not assert frontend when __experimentalBlockSnapshots is defined.
+				 * Not assert frontend when blockSnapshots is defined.
 				 * We will only do assertions before the end of responsiveAssertion tests.
 				 */
-				if ( ! __experimentalBlockSnapshots && assertFrontend && frontendCallback ) {
+				if ( ! blockSnapshots && assertFrontend && frontendCallback ) {
 					cy.getPreviewMode().then( previewMode => {
 						cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
 							cy.visit( previewUrl )
@@ -250,11 +250,11 @@ export const responsiveAssertHelper = ( callback = () => {}, options = {} ) => {
 	const responsiveAssertFunctions = viewports.map( viewport => {
 		const assertDesktopOnlyFunction = generateAssertDesktopOnlyFunction( viewport )
 		if ( disableItAssertion ) {
-			return () => callback( viewport, assertDesktopOnlyFunction, __experimentalRegisterBlockSnapshots )
+			return () => callback( viewport, assertDesktopOnlyFunction, registerBlockSnapshots )
 		}
 		return () => {
 			it( `should adjust ${ lowerCase( viewport ) } options inside ${ lowerCase( tab ) } tab`, () => {
-				callback( viewport, assertDesktopOnlyFunction, __experimentalRegisterBlockSnapshots )
+				callback( viewport, assertDesktopOnlyFunction, registerBlockSnapshots )
 			} )
 		}
 	} )

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -7,6 +7,7 @@ import {
 } from './util'
 import config from '../../cypress.json'
 import { collapse, openSidebar } from './commands/inspector'
+import { registerBlockSnapshots as __experimentalRegisterBlockSnapshots } from './blockSnapshots'
 
 /**
  * External dependencies
@@ -127,13 +128,14 @@ export const switchLayouts = ( blockName = 'ugb/accordion', layouts = [] ) => ()
  * @param {Function} frontendCallback
  * @param {Object} options
  */
-export const assertFunction = ( subject, editorCallback = () => {}, frontendCallback = () => {}, options = {} ) => {
+export const assertFunction = ( subject, editorCallback = () => {}, frontendCallback = null, options = {} ) => {
 	const {
 		assertFrontend = true,
-		assertBackend = true,
 		wait = 0,
 		viewportFrontend = false,
+		__experimentalBlockSnapshots = false,
 	} = options
+
 	getActiveTab( tab => {
 		cy.document().then( doc => {
 			const activePanel = doc.querySelector( 'button.components-panel__body-toggle[aria-expanded="true"]' ).innerText
@@ -146,15 +148,17 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 
 				cy.wait( wait )
 
-				if ( assertBackend ) {
-					cy.getPreviewMode().then( previewMode => {
-						editorCallback( {
-							parsedClassList, viewport: previewMode,
-						} )
+				cy.getPreviewMode().then( previewMode => {
+					editorCallback( {
+						parsedClassList, viewport: previewMode, blockContent: saveElement,
 					} )
-				}
+				} )
 
-				if ( assertFrontend ) {
+				/**
+				 * Not assert frontend when __experimentalBlockSnapshots is defined.
+				 * We will only do assertions before the end of responsiveAssertion tests.
+				 */
+				if ( ! __experimentalBlockSnapshots && assertFrontend && frontendCallback ) {
 					cy.getPreviewMode().then( previewMode => {
 						cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
 							cy.visit( previewUrl )
@@ -191,15 +195,16 @@ export const assertFunction = ( subject, editorCallback = () => {}, frontendCall
 * @param {string} name
 * @param {string} selector
 * @param {Object} options
+* @param {Object} assertOptions
 */
-export const assertAligns = ( name, selector, options = {} ) => {
+export const assertAligns = ( name, selector, options = {}, assertOptions = {} ) => {
 	const aligns = [ 'left', 'center', 'right' ]
 	aligns.forEach( align => {
 		cy.adjust( name, align, options ).assertComputedStyle( {
 			[ selector ]: {
 				'text-align': align,
 			},
-		} )
+		}, assertOptions )
 	} )
 }
 
@@ -245,11 +250,11 @@ export const responsiveAssertHelper = ( callback = () => {}, options = {} ) => {
 	const responsiveAssertFunctions = viewports.map( viewport => {
 		const assertDesktopOnlyFunction = generateAssertDesktopOnlyFunction( viewport )
 		if ( disableItAssertion ) {
-			return () => callback( viewport, assertDesktopOnlyFunction )
+			return () => callback( viewport, assertDesktopOnlyFunction, __experimentalRegisterBlockSnapshots )
 		}
 		return () => {
 			it( `should adjust ${ lowerCase( viewport ) } options inside ${ lowerCase( tab ) } tab`, () => {
-				callback( viewport, assertDesktopOnlyFunction )
+				callback( viewport, assertDesktopOnlyFunction, __experimentalRegisterBlockSnapshots )
 			} )
 		}
 	} )
@@ -262,8 +267,9 @@ export const responsiveAssertHelper = ( callback = () => {}, options = {} ) => {
 *
 * @param {string} selector
 * @param {Object} options
+* @param {Object} assertOptions
 */
-export const assertTypography = ( selector, options = {} ) => {
+export const assertTypography = ( selector, options = {}, assertOptions = {} ) => {
 	const {
 		viewport = 'Desktop',
 	} = options
@@ -283,7 +289,7 @@ export const assertTypography = ( selector, options = {} ) => {
 				'line-height': '4em',
 				'letter-spacing': '2.9px',
 			},
-		} )
+		}, assertOptions )
 	}
 	cy.adjust( 'Typography', {
 		'Size': {
@@ -301,7 +307,7 @@ export const assertTypography = ( selector, options = {} ) => {
 			'font-size': '2em',
 			'line-height': '24px',
 		},
-	} )
+	}, assertOptions )
 	cy.adjust( 'Typography', {
 		'Size': {
 			viewport,
@@ -318,5 +324,131 @@ export const assertTypography = ( selector, options = {} ) => {
 			'font-size': '50px',
 			'line-height': '4em',
 		},
+	}, assertOptions )
+}
+
+export const assertContainer = ( selector, options = {}, attrNameTemplate = 'column%sBackgroundMediaUrl' ) => {
+	const {
+		viewport,
+	} = options
+	const desktopOnly = callback => viewport === 'Desktop' && callback()
+	const attributeName = attrNameTemplate.replace( '%s', viewport === 'Desktop' ? '' : viewport )
+
+	// Adjust single container color options.
+	desktopOnly( () => {
+		cy.adjust( 'Background', {
+			'Color Type': 'single',
+			'Background Color': '#632d2d',
+		} ).assertComputedStyle( {
+			[ selector ]: {
+				'background-color': 'rgb(99, 45, 45)',
+			},
+			[ `${ selector }:before` ]: {
+				'background-color': '#632d2d',
+			},
+		} )
+	} )
+
+	// Adjust gradient container color options.
+	desktopOnly( () => {
+		cy.adjust( 'Background', {
+			'Color Type': 'gradient',
+			'Background Color #1': '#a92323',
+			'Background Color #2': '#404633',
+			'Adv. Gradient Color Settings': {
+				'Gradient Direction (degrees)': 180,
+				'Color 1 Location': '11%',
+				'Color 2 Location': '80%',
+				'Background Gradient Blend Mode': 'hard-light',
+			},
+		} ).assertComputedStyle( {
+			[ `${ selector }:before` ]: {
+				'background-image': 'linear-gradient(180deg, #a92323 11%, #404633)',
+				'mix-blend-mode': 'hard-light',
+			},
+		} )
+	} )
+
+	cy.setBlockAttribute( {
+		[ attributeName ]: Cypress.env( 'DUMMY_IMAGE_URL' ),
+	} )
+
+	desktopOnly( () => {
+		cy.adjust( 'Background', {
+			'Background Media Tint Strength': 5,
+			'Fixed Background': true,
+			'Adv. Background Image Settings': {
+				'Image Blend Mode': 'hue',
+			},
+		} ).assertComputedStyle( {
+			[ `${ selector }:before` ]: {
+				'background-blend-mode': 'hue',
+				'background-image': `url("${ Cypress.env( 'DUMMY_IMAGE_URL' ) }")`,
+				'background-attachment': 'fixed',
+			},
+		} )
+	} )
+
+	cy.adjust( 'Background', {
+		'Adv. Background Image Settings': {
+			'Image Position': {
+				viewport,
+				value: 'center center',
+			},
+			'Image Repeat': {
+				viewport,
+				value: 'repeat-x',
+			},
+			'Image Size': {
+				viewport,
+				value: 'custom',
+			},
+			'Custom Size': {
+				viewport,
+				value: 19,
+				unit: '%',
+			},
+		},
+	} ).assertComputedStyle( {
+		[ selector ]: {
+			'background-position': '50% 50%',
+			'background-repeat': 'repeat-x',
+			'background-size': '19%',
+		},
+	} )
+
+	// Test Border Radius
+	desktopOnly( () => {
+		cy.adjust( 'Border Radius', 30 ).assertComputedStyle( {
+			[ selector  ]: {
+				'border-radius': '30px',
+			},
+		} )
+	} )
+
+	// Test Border Options
+	cy.adjust( 'Borders', 'solid' )
+	desktopOnly( () => {
+		cy.adjust( 'Border Color', '#f1f1f1' ).assertComputedStyle( {
+			[ selector ]: {
+				'border-style': 'solid',
+				'border-color': '#f1f1f1',
+			},
+		} )
+	} )
+	cy.adjust( 'Border Width', 3, { viewport } ).assertComputedStyle( {
+		[ selector ]: {
+			'border-top-width': '3px',
+			'border-bottom-width': '3px',
+			'border-left-width': '3px',
+			'border-right-width': '3px',
+		},
+
+	} )
+
+	// Test Shadow / Outline
+	desktopOnly( () => {
+		cy.adjust( 'Shadow / Outline', 9 )
+			.assertClassName( selector, 'ugb--shadow-9' )
 	} )
 }

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -276,7 +276,7 @@ export const assertTypography = ( selector, options = {}, assertOptions = {} ) =
 
 	if ( viewport === 'Desktop' ) {
 		cy.adjust( 'Typography', {
-			'Size': 50,
+			'Size': { value: 50, unit: 'px' },
 			'Weight': '700',
 			'Transform': 'lowercase',
 			'Line-Height': 4,

--- a/cypress/support/modules.js
+++ b/cypress/support/modules.js
@@ -7,8 +7,9 @@ import { assertAligns, responsiveAssertHelper } from './helpers'
  * Assertion function for Block Title and Block Description.
  *
  * @param {Object} options
+ * @param {Object} assertOptions
  */
-export const assertBlockTitleDescription = ( options = {} ) => {
+export const assertBlockTitleDescription = ( options = {}, assertOptions = {} ) => {
 	const {
 		viewport = 'Desktop',
 	} = options
@@ -18,7 +19,7 @@ export const assertBlockTitleDescription = ( options = {} ) => {
 			cy.collapse( 'Block Title' )
 			cy.toggleStyle( 'Block Title' )
 			cy.adjust( 'Title HTML Tag', 'h2' )
-				.assertHtmlTag( '.ugb-block-title', 'h2' )
+				.assertHtmlTag( '.ugb-block-title', 'h2', assertOptions )
 			cy.adjust( 'Typography', {
 				'Font Family': 'Sans-Serif',
 				'Size': 31,
@@ -42,19 +43,19 @@ export const assertBlockTitleDescription = ( options = {} ) => {
 					'max-width': '748px',
 					'line-height': '46px',
 				},
-			} )
+			}, assertOptions )
 			cy.adjust( 'Horizontal Align', 'flex-start' ).assertComputedStyle( {
 				'.ugb-block-title': {
 					'margin-left': '0px',
 				},
-			} )
+			}, assertOptions )
 			cy.adjust( 'Horizontal Align', 'center' )
 			cy.adjust( 'Horizontal Align', 'flex-end' ).assertComputedStyle( {
 				'.ugb-block-title': {
 					'margin-right': '0px',
 				},
 			} )
-			assertAligns( 'Text Align', '.ugb-block-title' )
+			assertAligns( 'Text Align', '.ugb-block-title', {}, assertOptions )
 
 			cy.collapse( 'Block Description' )
 			cy.toggleStyle( 'Block Description' )
@@ -81,21 +82,21 @@ export const assertBlockTitleDescription = ( options = {} ) => {
 					'max-width': '734px',
 					'line-height': '36px',
 				},
-			} )
+			}, assertOptions )
 			cy.adjust( 'Horizontal Align', 'flex-start' ).assertComputedStyle( {
 				'.ugb-block-description': {
 					'margin-left': '0px',
 				},
-			} )
+			}, assertOptions )
 			cy.adjust( 'Horizontal Align', 'center' )
 			cy.adjust( 'Horizontal Align', 'flex-end' ).assertComputedStyle( {
 				'.ugb-block-description': {
 					'margin-right': '0px',
 				},
-			} )
+			}, assertOptions )
 
 			// Test Block Description Alignment
-			assertAligns( 'Text Align', '.ugb-block-description' )
+			assertAligns( 'Text Align', '.ugb-block-description', {}, assertOptions )
 		} )
 
 		const tabletMobileViewports = [ 'Tablet', 'Mobile' ]
@@ -126,9 +127,9 @@ export const assertBlockTitleDescription = ( options = {} ) => {
 					'max-width': '748px',
 					'line-height': '42px',
 				},
-			} )
+			}, assertOptions )
 
-			assertAligns( 'Text Align', '.ugb-block-title', { viewport } )
+			assertAligns( 'Text Align', '.ugb-block-title', { viewport }, assertOptions )
 
 			cy.collapse( 'Block Description' )
 			cy.toggleStyle( 'Block Description' )
@@ -156,9 +157,9 @@ export const assertBlockTitleDescription = ( options = {} ) => {
 					'max-width': '748px',
 					'line-height': '38px',
 				},
-			} )
+			}, assertOptions )
 
-			assertAligns( 'Text Align', '.ugb-block-description', { viewport } )
+			assertAligns( 'Text Align', '.ugb-block-description', { viewport }, assertOptions )
 		}
 	}
 
@@ -174,8 +175,9 @@ export const assertBlockTitleDescription = ( options = {} ) => {
  *
  * @param {string} selector
  * @param {Object} options
+ * @param {Object} assertOptions
  */
-export const assertBlockBackground = ( selector, options = {} ) => {
+export const assertBlockBackground = ( selector, options = {}, assertOptions = {} ) => {
 	const {
 		viewport = 'Desktop',
 	} = options
@@ -189,7 +191,7 @@ export const assertBlockBackground = ( selector, options = {} ) => {
 				[ selector ]: {
 					'background-color': 'rgba(255, 255, 255, 0.7)',
 				},
-			} )
+			}, assertOptions )
 		} )
 		cy.setBlockAttribute( { [ `blockBackground${ viewport === 'Desktop' ? '' : viewport }BackgroundMediaUrl` ]: Cypress.env( 'DUMMY_IMAGE_URL' ) } )
 		desktopOnly( () => {
@@ -217,7 +219,7 @@ export const assertBlockBackground = ( selector, options = {} ) => {
 					'background-attachment': 'fixed',
 					'background-blend-mode': 'multiply',
 				},
-			} )
+			}, assertOptions )
 		} )
 		cy.adjust( 'Adv. Background Image Settings', {
 			'Image Position': {
@@ -243,7 +245,7 @@ export const assertBlockBackground = ( selector, options = {} ) => {
 				'background-repeat': 'repeat-x',
 				'background-size': '19%',
 			},
-		} )
+		}, assertOptions )
 	}
 
 	const [ Desktop, Tablet, Mobile ] = responsiveAssertHelper( _assertBlockBackground, { disableItAssertion: true } )
@@ -257,8 +259,9 @@ export const assertBlockBackground = ( selector, options = {} ) => {
  * Assertion function for Top and Bottom Separator.
  *
  * @param {Object} options
+ * @param {Object} assertOptions
  */
-export const assertSeparators = ( options = {} ) => {
+export const assertSeparators = ( options = {}, assertOptions = {} ) => {
 	const {
 		viewport = 'Desktop',
 	} = options
@@ -283,7 +286,7 @@ export const assertSeparators = ( options = {} ) => {
 			'.ugb-top-separator>.ugb-separator-wrapper': {
 				'height': '191px',
 			},
-		} )
+		}, assertOptions )
 		desktopOnly( () => {
 			cy.adjust( 'Design', 'wave-2' )
 			cy.adjust( 'Color', '#000000' )
@@ -299,7 +302,7 @@ export const assertSeparators = ( options = {} ) => {
 				'.ugb-top-separator': {
 					'z-index': '6',
 				},
-			} ] )
+			}, assertOptions ] )
 			cy.adjust( 'Separator Layer 2', {
 				'Color': '#ffffff',
 				'Layer Height': '1.16',
@@ -314,7 +317,7 @@ export const assertSeparators = ( options = {} ) => {
 					'opacity': '0.3',
 					'mix-blend-mode': 'overlay',
 				},
-			} )
+			}, assertOptions )
 
 			cy.adjust( 'Separator Layer 3', {
 				'Color': '#6d6d6d',
@@ -328,7 +331,7 @@ export const assertSeparators = ( options = {} ) => {
 					'transform': 'matrix(-1.2, 0, 0, 1.03, 0, 0)',
 					'opacity': '0.8',
 				},
-			} )
+			}, assertOptions )
 		} )
 		cy.collapse( 'Bottom Separator' )
 		cy.toggleStyle( 'Bottom Separator' )
@@ -336,7 +339,7 @@ export const assertSeparators = ( options = {} ) => {
 			'.ugb-bottom-separator>.ugb-separator-wrapper': {
 				'height': '150px',
 			},
-		} )
+		}, assertOptions )
 		desktopOnly( () => {
 			cy.adjust( 'Design', 'curve-3' )
 			cy.adjust( 'Color', '#f00069' )
@@ -352,7 +355,7 @@ export const assertSeparators = ( options = {} ) => {
 				'.ugb-top-separator': {
 					'z-index': '6',
 				},
-			} ] )
+			}, assertOptions ] )
 			cy.adjust( 'Separator Layer 2', {
 				'Color': '#ffffff',
 				'Layer Height': '1.16',
@@ -367,7 +370,7 @@ export const assertSeparators = ( options = {} ) => {
 					'opacity': '0.3',
 					'mix-blend-mode': 'saturation',
 				},
-			} )
+			}, assertOptions )
 
 			cy.adjust( 'Separator Layer 3', {
 				'Color': '#6d6d6d',
@@ -381,7 +384,7 @@ export const assertSeparators = ( options = {} ) => {
 					'transform': 'matrix(-1.2, 0, 0, 1.03, 0, 0)',
 					'opacity': '0.8',
 				},
-			} )
+			}, assertOptions )
 		} )
 	}
 

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -55,11 +55,12 @@ export function changeUnit( unit = '', name = '', isInPopover = false ) {
  * Function used to generate a parsed class names to be
  * used as a selector.
  *
- * @param {Array} classList
+ * @param {string} classList
  */
-export function parseClassList( classList = [] ) {
+export function parseClassList( classList = '' ) {
 	const excludedClassNames = [
 		'ugb-accordion--open',
+		'ugb-accordion--single-open',
 		'ugb-icon-list__left-align',
 		'ugb-icon-list__center-align',
 		'ugb-icon-list__right-align',
@@ -134,3 +135,4 @@ export function dispatchResolver( resolver = () => {} ) {
 		resolver()
 	}, 1 )
 }
+

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -136,3 +136,42 @@ export function dispatchResolver( resolver = () => {} ) {
 	}, 1 )
 }
 
+/**
+ * Function for returning a stringified path location of the block from
+ * `wp.data.select('core/block-editor').getBlocks()` by clientId
+ *
+ * e.g. [0].innerBlocks[2]
+ *
+ * @param {Array} blocks
+ * @param {string} clientId
+ *
+ * @return {string} stringified path
+ */
+export function getBlockStringPath( blocks = [], clientId = '' ) {
+	const paths = []
+	let found = false
+
+	function getBlockStringPathRecursive( _blocks, clientId ) {
+		_blocks.forEach( ( _block, index ) => {
+			if ( ! found ) {
+				paths.push( `[${ index }]` )
+			}
+			if ( ! found && _block.clientId === clientId ) {
+				found = true
+			}
+			if ( ! found && _block.innerBlocks.length ) {
+				paths.push( '.innerBlocks' )
+				getBlockStringPathRecursive( _block.innerBlocks, clientId )
+				if ( ! found ) {
+					paths.pop()
+				}
+			}
+			if ( ! found ) {
+				paths.pop()
+			}
+		} )
+	}
+
+	getBlockStringPathRecursive( blocks, clientId )
+	return paths.join( '' )
+}

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -54,28 +54,6 @@ export function changeUnit( unit = '', name = '', isInPopover = false ) {
 }
 
 /**
- * Function used to generate a parsed class names to be
- * used as a selector.
- *
- * @param {string} classList
- */
-export function parseClassList( classList = '' ) {
-	const excludedClassNames = [
-		'ugb-accordion--open',
-		'ugb-accordion--single-open',
-		'ugb-icon-list__left-align',
-		'ugb-icon-list__center-align',
-		'ugb-icon-list__right-align',
-		'alignfull',
-	]
-	const parsedClassList = classList.split( ' ' )
-		.filter( className => ! className.match( /ugb-(.......)$/ ) && ! excludedClassNames.includes( className ) )
-		.map( className => `.${ className }` )
-		.join( '' )
-	return parsedClassList
-}
-
-/**
  * Function for getting the active tab
  * in inspector.
  *


### PR DESCRIPTION
## Block Snapshots
`wp.blocks.getBlockContent` can be used to generate block HTML content. With this,
we can overwrite `getComputedStyle` to stub all generated HTML contents and CSS objects for future assertions.

#### Usage:
```
function desktopStyles( viewport, desktopOnly, registerBlockSnapshots ) {
    cy.setupWP()
    cy.newPage()
    cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )
    const accordionBlock = registerBlockSnapshots( 'accordionBlock' )
    
    // More tests...
    // assertComputedStyle will no longer assert the frontend
    // every call. Instead, block snapshots will be stubbed and
    // can be enqueued before the end of the test.

    // Enqueue all block snapshots and assert frontend styles.
    accordionBlock.assertFrontendStyles()
}
```

### Changelog
- `assertHtmlTag` command will no longer visit the frontend for assertions.
- `assertHtmlAttribute` command will no longer visit the frontend for assertions.
- `assertClassname` command will no longer visit the frontend for assertions.
- Fixed `assertComputedStyle` assertion bug.
- Added `assertContainer` helper.
- Fixed more tests.

### Passing Tests
- [x] Accordion
- [x] Blockquote
- [x] Button
- [x] Card (related: https://github.com/gambitph/Stackable/pull/1057 )
- [x] Container
- [x] Count-up (related: https://github.com/gambitph/Stackable/pull/1059)
- [x] Call to Action
- [x] Divider
- [x] Expand
- [x] Feature Grid
- [x] Header
- [x] Heading
- [x] Icon
- [x] Icon List
- [x] Notification (related: https://github.com/gambitph/Stackable/pull/1061)
- [x] Separator
- [x] Spacer
- [x] Text

Fixes #68