### PR TITLE
added test for typing content into blocks

### DIFF
--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -79,7 +79,7 @@ function typeContent() {
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 
@@ -221,7 +221,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	accordionBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -72,12 +72,10 @@ function typeContent() {
 		cy.setupWP()
 		cy.newPage()
 		cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )
-		const accordionBlock = registerBlockSnapshots( 'accordionBlock' )
+		registerBlockSnapshots( 'accordionBlock' )
 
 		cy.typeBlock( 'ugb/accordion', '.ugb-accordion__title', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-accordion__title', 'Hello World! 1234' )
-
-		accordionBlock.assertFrontendContent()
 	} )
 }
 

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -73,6 +73,11 @@ function typeContent() {
 		cy.addBlock( 'ugb/accordion' )
 		cy.typeBlock( 'ugb/accordion', '.ugb-accordion__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/accordion', '.block-editor-block-list__block', 'Hello World! 1234' )
+		cy.get( '.ugb-accordion' )
+			.find( '.block-editor-block-list__block' )
+			.then( $textBlock => {
+				$textBlock.addClass( 'e2e-paragraph' )
+			} )
 
 		cy.publish()
 		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
@@ -82,7 +87,7 @@ function typeContent() {
 				.contains( 'Hello World! 1234' )
 				.should( 'exist' )
 			cy.get( '.ugb-accordion' )
-				.find( '.block-editor-block-list__block' )
+				.find( '.e2e-paragraph' )
 				.contains( 'Hello World! 1234' )
 				.should( 'exist' )
 			cy.visit( editorUrl )

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -17,6 +17,7 @@ describe( 'Accordion Block', registerTests( [
 	innerBlocks,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -63,6 +64,30 @@ function switchDesign() {
 		'Elevate Accordion',
 		'Lounge Accordion',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/accordion' )
+		cy.typeBlock( 'ugb/accordion', '.ugb-accordion__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/accordion', '.block-editor-block-list__block', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-accordion' )
+				.find( '.ugb-accordion__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-accordion' )
+				.find( '.block-editor-block-list__block' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -7,6 +7,7 @@ import { blocks } from '~stackable-e2e/config'
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, assertAligns, registerTests, responsiveAssertHelper, assertTypography, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -70,28 +71,13 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/accordion' )
-		cy.typeBlock( 'ugb/accordion', '.ugb-accordion__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/accordion', '.block-editor-block-list__block', 'Hello World! 1234' )
-		cy.get( '.ugb-accordion' )
-			.find( '.block-editor-block-list__block' )
-			.then( $textBlock => {
-				$textBlock.addClass( 'e2e-paragraph' )
-			} )
+		cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )
+		const accordionBlock = registerBlockSnapshots( 'accordionBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-accordion' )
-				.find( '.ugb-accordion__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-accordion' )
-				.find( '.e2e-paragraph' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/accordion', '.ugb-accordion__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-accordion__title', 'Hello World! 1234' )
+
+		accordionBlock.assertFrontendContent()
 	} )
 }
 

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -221,7 +221,7 @@ function styleTab( viewport, desktopOnly ) {
 	accordionBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )

--- a/cypress/integration/v2/blocks/accordion.spec.js
+++ b/cypress/integration/v2/blocks/accordion.spec.js
@@ -136,25 +136,24 @@ function styleTab( viewport, desktopOnly ) {
 					cy.visit( editorUrl )
 				} )
 		} )
-
-		// Test 'Reverse arrow'
-		cy.openInspector( 'ugb/accordion', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Reverse arrow', true ).assertComputedStyle( {
-			'.ugb-accordion__heading': {
-				'flex-direction': 'row-reverse',
-			},
-		} )
 		cy.deleteBlock( 'ugb/accordion', 'Accordion 1' )
 	} )
 
 	cy.addBlock( 'ugb/accordion' ).as( 'accordionBlock' )
 	const accordionBlock = registerBlockSnapshots( 'accordionBlock' )
 
-	// Test General Alignment
+	// Test General Reverse Arrow and Alignment
 	cy.openInspector( 'ugb/accordion', 'Style' )
 	cy.collapse( 'General' )
 	cy.adjust( 'Open at the start', true )
+
+	desktopOnly( () => {
+		cy.adjust( 'Reverse arrow', true ).assertComputedStyle( {
+			'.ugb-accordion__heading': {
+				'flex-direction': 'row-reverse',
+			},
+		} )
+	} )
 	assertAligns( 'Align', '.ugb-inner-block', { viewport } )
 
 	cy.collapse( 'Container' )

--- a/cypress/integration/v2/blocks/blockquote.spec.js
+++ b/cypress/integration/v2/blocks/blockquote.spec.js
@@ -72,7 +72,7 @@ function typeContent() {
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/blockquote' ).as( 'blockquoteBlock' )
@@ -156,7 +156,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	blockquoteBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/blockquote' ).as( 'blockquoteBlock' )

--- a/cypress/integration/v2/blocks/blockquote.spec.js
+++ b/cypress/integration/v2/blocks/blockquote.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, assertAligns, registerTests, responsiveAssertHelper, assertBlockBackground, assertSeparators, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -63,18 +64,11 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/blockquote' )
-		cy.typeBlock( 'ugb/blockquote', '.ugb-blockquote__text', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/blockquote' ).as( 'blockquoteBlock' )
+		registerBlockSnapshots( 'blockquoteBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-blockquote' )
-				.find( '.ugb-blockquote__text' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/blockquote', '.ugb-blockquote__text', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-blockquote__text', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/blockquote.spec.js
+++ b/cypress/integration/v2/blocks/blockquote.spec.js
@@ -156,7 +156,7 @@ function styleTab( viewport, desktopOnly ) {
 	blockquoteBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/blockquote' ).as( 'blockquoteBlock' )

--- a/cypress/integration/v2/blocks/blockquote.spec.js
+++ b/cypress/integration/v2/blocks/blockquote.spec.js
@@ -13,6 +13,7 @@ describe( 'Blockquote Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -56,6 +57,25 @@ function switchDesign() {
 		'Seren Blockquote',
 		'Yule Blockquote',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/blockquote' )
+		cy.typeBlock( 'ugb/blockquote', '.ugb-blockquote__text', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-blockquote' )
+				.find( '.ugb-blockquote__text' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/blog-posts.spec.js
+++ b/cypress/integration/v2/blocks/blog-posts.spec.js
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
 
@@ -12,6 +13,7 @@ describe( 'Blog Posts Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopAdvanced,
 	tabletAdvanced,
 	mobileAdvanced,
@@ -53,6 +55,23 @@ function switchDesign() {
 		'Prime Blog Post',
 		'Propel Blog Post',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/blog-posts' ).as( 'blogPostsBlock' )
+		registerBlockSnapshots( 'blogPostsBlock' )
+
+		cy.openInspector( 'ugb/blog-posts', 'Style' )
+		cy.toggleStyle( 'Load More Button' )
+
+		cy.typeBlock( 'ugb/blog-posts', '.ugb-button--inner', 'Helloo World!! 12345' )
+			.assertBlockContent( '.ugb-button--inner', 'Helloo World!! 12345' )
+
+		assertBlockTitleDescriptionContent( 'ugb/blog-posts' )
+	} )
 }
 
 function advancedTab( viewport ) {

--- a/cypress/integration/v2/blocks/button.spec.js
+++ b/cypress/integration/v2/blocks/button.spec.js
@@ -181,7 +181,7 @@ function styleTab( viewport, desktopOnly ) {
 	buttonBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/button' ).as( 'buttonBlock' )

--- a/cypress/integration/v2/blocks/button.spec.js
+++ b/cypress/integration/v2/blocks/button.spec.js
@@ -64,7 +64,7 @@ function typeContent() {
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/button' ).as( 'buttonBlock' )
@@ -181,7 +181,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	buttonBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/button' ).as( 'buttonBlock' )

--- a/cypress/integration/v2/blocks/button.spec.js
+++ b/cypress/integration/v2/blocks/button.spec.js
@@ -13,6 +13,7 @@ describe( 'Button Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -48,6 +49,25 @@ function switchDesign() {
 		'Heights Button',
 		'Lume Button',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/button' )
+		cy.typeBlock( 'ugb/button', '.ugb-button--inner', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-button' )
+				.find( '.ugb-button--inner' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/button.spec.js
+++ b/cypress/integration/v2/blocks/button.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertBlockBackground, assertSeparators, assertAdvancedTab, assertTypography,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -55,18 +56,11 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/button' )
-		cy.typeBlock( 'ugb/button', '.ugb-button--inner', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/button' ).as( 'buttonBlock' )
+		registerBlockSnapshots( 'buttonBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-button' )
-				.find( '.ugb-button--inner' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/button', '.ugb-button--inner', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/card.spec.js
+++ b/cypress/integration/v2/blocks/card.spec.js
@@ -13,6 +13,7 @@ describe( 'Card Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -65,6 +66,45 @@ function switchDesign() {
 		'Speck Card',
 		'Yule Card',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/card' )
+
+		cy.openInspector( 'ugb/card', 'Style' )
+		cy.collapse( 'General' )
+		cy.adjust( 'Columns', 1 )
+
+		cy.typeBlock( 'ugb/card', '.ugb-card__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/card', '.ugb-card__subtitle', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/card', '.ugb-card__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/card', '.ugb-button--inner', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-card' )
+				.find( '.ugb-card__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-card' )
+				.find( '.ugb-card__subtitle' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-card' )
+				.find( '.ugb-card__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-card' )
+				.find( '.ugb-button--inner' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/card.spec.js
+++ b/cypress/integration/v2/blocks/card.spec.js
@@ -80,20 +80,20 @@ function typeContent() {
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
-		cy.typeBlock( 'ugb/card', '.ugb-card__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-card__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/card', '.ugb-card__subtitle', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-card__subtitle', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/card', '.ugb-card__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-card__description', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/card', '.ugb-button--inner', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/card', '.ugb-card__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-card__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/card', '.ugb-card__subtitle', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-card__subtitle', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/card', '.ugb-card__description', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-card__description', 'Hellooo World!!! 123' )
+		cy.typeBlock( 'ugb/card', '.ugb-button--inner', 'Helloooo World!!!! 1234' )
+			.assertBlockContent( '.ugb-button--inner', 'Helloooo World!!!! 1234' )
 
 		assertBlockTitleDescriptionContent( 'ugb/card' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/card' ).as( 'cardBlock' )
@@ -324,7 +324,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	cardBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/card' ).as( 'cardBlock' )

--- a/cypress/integration/v2/blocks/card.spec.js
+++ b/cypress/integration/v2/blocks/card.spec.js
@@ -76,10 +76,6 @@ function typeContent() {
 		cy.addBlock( 'ugb/card' ).as( 'cardBlock' )
 		registerBlockSnapshots( 'cardBlock' )
 
-		cy.openInspector( 'ugb/card', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Columns', 1 )
-
 		cy.typeBlock( 'ugb/card', '.ugb-card__title', 'Hello World! 1' )
 			.assertBlockContent( '.ugb-card__title', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/card', '.ugb-card__subtitle', 'Helloo World!! 12' )
@@ -89,6 +85,7 @@ function typeContent() {
 		cy.typeBlock( 'ugb/card', '.ugb-button--inner', 'Helloooo World!!!! 1234' )
 			.assertBlockContent( '.ugb-button--inner', 'Helloooo World!!!! 1234' )
 
+		cy.openInspector( 'ugb/card', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/card' )
 	} )
 }
@@ -324,7 +321,7 @@ function styleTab( viewport, desktopOnly ) {
 	cardBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/card' ).as( 'cardBlock' )

--- a/cypress/integration/v2/blocks/card.spec.js
+++ b/cypress/integration/v2/blocks/card.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertContainer, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
@@ -88,6 +88,8 @@ function typeContent() {
 			.assertBlockContent( '.ugb-card__description', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/card', '.ugb-button--inner', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/card' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/card.spec.js
+++ b/cypress/integration/v2/blocks/card.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -72,38 +73,21 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/card' )
+		cy.addBlock( 'ugb/card' ).as( 'cardBlock' )
+		registerBlockSnapshots( 'cardBlock' )
 
 		cy.openInspector( 'ugb/card', 'Style' )
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
 		cy.typeBlock( 'ugb/card', '.ugb-card__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-card__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/card', '.ugb-card__subtitle', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-card__subtitle', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/card', '.ugb-card__description', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-card__description', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/card', '.ugb-button--inner', 'Hello World! 1234' )
-
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-card' )
-				.find( '.ugb-card__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-card' )
-				.find( '.ugb-card__subtitle' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-card' )
-				.find( '.ugb-card__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-card' )
-				.find( '.ugb-button--inner' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/columns.spec.js
+++ b/cypress/integration/v2/blocks/columns.spec.js
@@ -4,8 +4,9 @@
 import { range } from 'lodash'
 import { blocks } from '~stackable-e2e/config'
 import {
-	assertBlockExist, blockErrorTest, switchLayouts, registerTests, responsiveAssertHelper, assertAdvancedTab, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators,
+	assertBlockExist, blockErrorTest, switchLayouts, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAdvancedTab, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -15,6 +16,7 @@ describe( 'Advanced Columns and Grid Block', registerTests( [
 	blockError,
 	innerBlocks,
 	switchLayout,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -53,6 +55,18 @@ function switchLayout() {
 		{ value: 'Uneven 2', selector: '.ugb-columns--design-uneven-2' },
 		{ value: 'Tiled', selector: '.ugb-columns--design-tiled' },
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/columns' ).as( 'columnsBlock' )
+		registerBlockSnapshots( 'columnsBlock' )
+		cy.openInspector( 'ugb/columns', 'Style' )
+
+		assertBlockTitleDescriptionContent( 'ugb/columns' )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/columns.spec.js
+++ b/cypress/integration/v2/blocks/columns.spec.js
@@ -69,7 +69,7 @@ function typeContent() {
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/columns' ).as( 'columnsBlock' )
@@ -183,7 +183,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	// TODO: Add style assertion for one column
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/columns' ).as( 'columnsBlock' )

--- a/cypress/integration/v2/blocks/container.spec.js
+++ b/cypress/integration/v2/blocks/container.spec.js
@@ -5,6 +5,7 @@ import { blocks } from '~stackable-e2e/config'
 import {
 	assertAligns, assertBlockBackground, assertBlockExist, assertSeparators, blockErrorTest, switchLayouts, registerTests, responsiveAssertHelper, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -54,7 +55,7 @@ function switchLayout() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/container' ).as( 'containerBlock' )
@@ -201,7 +202,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	containerBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/container' ).as( 'containerBlock' )

--- a/cypress/integration/v2/blocks/container.spec.js
+++ b/cypress/integration/v2/blocks/container.spec.js
@@ -202,7 +202,7 @@ function styleTab( viewport, desktopOnly ) {
 	containerBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/container' ).as( 'containerBlock' )

--- a/cypress/integration/v2/blocks/count-up.spec.js
+++ b/cypress/integration/v2/blocks/count-up.spec.js
@@ -70,18 +70,18 @@ function typeContent() {
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
-		cy.typeBlock( 'ugb/count-up', '.ugb-countup__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-countup__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/count-up', '.ugb-countup__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-countup__title', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/count-up', '.ugb-countup__counter', '1234' )
 			.assertBlockContent( '.ugb-countup__counter', '1234' )
-		cy.typeBlock( 'ugb/count-up', '.ugb-countup__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-countup__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/count-up', '.ugb-countup__description', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-countup__description', 'Helloo World!! 12' )
 
 		assertBlockTitleDescriptionContent( 'ugb/count-up' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/count-up' ).as( 'countUpBlock' )
@@ -293,7 +293,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	countUpBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/count-up' ).as( 'countUpBlock' )

--- a/cypress/integration/v2/blocks/count-up.spec.js
+++ b/cypress/integration/v2/blocks/count-up.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, responsiveAssertHelper, registerTests, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, responsiveAssertHelper, registerTests, assertBlockTitleDescriptionContent, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
@@ -76,6 +76,8 @@ function typeContent() {
 			.assertBlockContent( '.ugb-countup__counter', '1234' )
 		cy.typeBlock( 'ugb/count-up', '.ugb-countup__description', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-countup__description', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/count-up' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/count-up.spec.js
+++ b/cypress/integration/v2/blocks/count-up.spec.js
@@ -66,10 +66,6 @@ function typeContent() {
 		cy.addBlock( 'ugb/count-up' ).as( 'countUpBlock' )
 		registerBlockSnapshots( 'countUpBlock' )
 
-		cy.openInspector( 'ugb/count-up', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Columns', 1 )
-
 		cy.typeBlock( 'ugb/count-up', '.ugb-countup__title', 'Hello World! 1' )
 			.assertBlockContent( '.ugb-countup__title', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/count-up', '.ugb-countup__counter', '1234' )
@@ -77,6 +73,7 @@ function typeContent() {
 		cy.typeBlock( 'ugb/count-up', '.ugb-countup__description', 'Helloo World!! 12' )
 			.assertBlockContent( '.ugb-countup__description', 'Helloo World!! 12' )
 
+		cy.openInspector( 'ugb/count-up', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/count-up' )
 	} )
 }
@@ -293,7 +290,7 @@ function styleTab( viewport, desktopOnly ) {
 	countUpBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/count-up' ).as( 'countUpBlock' )

--- a/cypress/integration/v2/blocks/count-up.spec.js
+++ b/cypress/integration/v2/blocks/count-up.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, responsiveAssertHelper, registerTests, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -62,33 +63,19 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/count-up' )
+		cy.addBlock( 'ugb/count-up' ).as( 'countUpBlock' )
+		registerBlockSnapshots( 'countUpBlock' )
 
 		cy.openInspector( 'ugb/count-up', 'Style' )
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
 		cy.typeBlock( 'ugb/count-up', '.ugb-countup__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-countup__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/count-up', '.ugb-countup__counter', '1234' )
+			.assertBlockContent( '.ugb-countup__counter', '1234' )
 		cy.typeBlock( 'ugb/count-up', '.ugb-countup__description', 'Hello World! 1234' )
-
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-count-up' )
-				.find( '.ugb-countup__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-count-up' )
-				.find( '.ugb-countup__counter' )
-				.contains( '1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-count-up' )
-				.find( '.ugb-countup__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+			.assertBlockContent( '.ugb-countup__description', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/count-up.spec.js
+++ b/cypress/integration/v2/blocks/count-up.spec.js
@@ -13,6 +13,7 @@ describe( 'Count Up Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -55,6 +56,40 @@ function switchDesign() {
 		'Speck Count Up',
 		'Upland Count Up',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/count-up' )
+
+		cy.openInspector( 'ugb/count-up', 'Style' )
+		cy.collapse( 'General' )
+		cy.adjust( 'Columns', 1 )
+
+		cy.typeBlock( 'ugb/count-up', '.ugb-countup__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/count-up', '.ugb-countup__counter', '1234' )
+		cy.typeBlock( 'ugb/count-up', '.ugb-countup__description', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-count-up' )
+				.find( '.ugb-countup__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-count-up' )
+				.find( '.ugb-countup__counter' )
+				.contains( '1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-count-up' )
+				.find( '.ugb-countup__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/cta.spec.js
+++ b/cypress/integration/v2/blocks/cta.spec.js
@@ -13,6 +13,7 @@ describe( 'Call To Action Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -83,6 +84,35 @@ function switchDesign() {
 		'Upland Call to Action',
 		'Yule Call to Action',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/cta' )
+		cy.typeBlock( 'ugb/cta', '.ugb-cta__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/cta', '.ugb-cta__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/cta', '.ugb-button--inner', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-cta' )
+				.find( '.ugb-cta__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-cta' )
+				.find( '.ugb-cta__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-cta' )
+				.find( '.ugb-button--inner' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/cta.spec.js
+++ b/cypress/integration/v2/blocks/cta.spec.js
@@ -275,7 +275,7 @@ function styleTab( viewport, desktopOnly ) {
 	ctaBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/cta' ).as( 'ctaBlock' )

--- a/cypress/integration/v2/blocks/cta.spec.js
+++ b/cypress/integration/v2/blocks/cta.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertBlockBackground, assertSeparators, assertTypography, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -90,28 +91,15 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/cta' )
-		cy.typeBlock( 'ugb/cta', '.ugb-cta__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/cta', '.ugb-cta__description', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/cta', '.ugb-button--inner', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/cta' ).as( 'ctaBlock' )
+		registerBlockSnapshots( 'ctaBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-cta' )
-				.find( '.ugb-cta__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-cta' )
-				.find( '.ugb-cta__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-cta' )
-				.find( '.ugb-button--inner' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/cta', '.ugb-cta__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-cta__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/cta', '.ugb-cta__description', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-cta__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/cta', '.ugb-button--inner', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/cta.spec.js
+++ b/cypress/integration/v2/blocks/cta.spec.js
@@ -94,16 +94,16 @@ function typeContent() {
 		cy.addBlock( 'ugb/cta' ).as( 'ctaBlock' )
 		registerBlockSnapshots( 'ctaBlock' )
 
-		cy.typeBlock( 'ugb/cta', '.ugb-cta__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-cta__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/cta', '.ugb-cta__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-cta__description', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/cta', '.ugb-button--inner', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/cta', '.ugb-cta__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-cta__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/cta', '.ugb-cta__description', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-cta__description', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/cta', '.ugb-button--inner', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-button--inner', 'Hellooo World!!! 123' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/cta' ).as( 'ctaBlock' )
@@ -275,7 +275,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	ctaBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/cta' ).as( 'ctaBlock' )

--- a/cypress/integration/v2/blocks/divider.spec.js
+++ b/cypress/integration/v2/blocks/divider.spec.js
@@ -70,7 +70,7 @@ function styleTab( viewport, desktopOnly ) {
 	dividerBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/divider' ).as( 'dividerBlock' )

--- a/cypress/integration/v2/blocks/divider.spec.js
+++ b/cypress/integration/v2/blocks/divider.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchLayouts, assertAligns, registerTests, responsiveAssertHelper, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -37,7 +38,7 @@ function switchLayout() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/divider' ).as( 'dividerBlock' )
@@ -69,7 +70,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	dividerBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/divider' ).as( 'dividerBlock' )

--- a/cypress/integration/v2/blocks/expand.spec.js
+++ b/cypress/integration/v2/blocks/expand.spec.js
@@ -117,7 +117,7 @@ function styleTab( viewport, desktopOnly ) {
 	expandBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/expand' ).as( 'expandBlock' )

--- a/cypress/integration/v2/blocks/expand.spec.js
+++ b/cypress/integration/v2/blocks/expand.spec.js
@@ -11,6 +11,7 @@ const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelp
 describe( 'Expand Block', registerTests( [
 	blockExist,
 	blockError,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -25,6 +26,45 @@ function blockExist() {
 
 function blockError() {
 	it( 'should not trigger block error when refreshing the page', blockErrorTest( 'ugb/expand' ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/expand' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-text', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-toggle-text', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-text', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-toggle-text', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-expand' )
+				.find( '.ugb-expand__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-expand' )
+				.find( '.ugb-expand__less-text' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-expand' )
+				.find( '.ugb-expand__more-toggle-text' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-expand' )
+				.find( '.ugb-expand__more-text' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-expand' )
+				.find( '.ugb-expand__less-toggle-text' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/expand.spec.js
+++ b/cypress/integration/v2/blocks/expand.spec.js
@@ -36,20 +36,20 @@ function typeContent() {
 		cy.addBlock( 'ugb/expand' ).as( 'expandBlock' )
 		registerBlockSnapshots( 'expandBlock' )
 
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-expand__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-text', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-expand__less-text', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-toggle-text', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-expand__more-toggle-text', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-text', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-expand__more-text', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-toggle-text', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-expand__less-toggle-text', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-expand__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-text', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-expand__less-text', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-toggle-text', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-expand__more-toggle-text', 'Hellooo World!!! 123' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-text', 'Helloooo World!!!! 1234' )
+			.assertBlockContent( '.ugb-expand__more-text', 'Helloooo World!!!! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-toggle-text', 'Hellooooo World!!!!! 12345' )
+			.assertBlockContent( '.ugb-expand__less-toggle-text', 'Hellooooo World!!!!! 12345' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/expand' ).as( 'expandBlock' )
@@ -117,7 +117,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	expandBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/expand' ).as( 'expandBlock' )

--- a/cypress/integration/v2/blocks/expand.spec.js
+++ b/cypress/integration/v2/blocks/expand.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, assertAligns, registerTests, responsiveAssertHelper, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -32,38 +33,19 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/expand' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-text', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-toggle-text', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-text', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-toggle-text', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/expand' ).as( 'expandBlock' )
+		registerBlockSnapshots( 'expandBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-expand' )
-				.find( '.ugb-expand__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-expand' )
-				.find( '.ugb-expand__less-text' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-expand' )
-				.find( '.ugb-expand__more-toggle-text' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-expand' )
-				.find( '.ugb-expand__more-text' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-expand' )
-				.find( '.ugb-expand__less-toggle-text' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-expand__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-text', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-expand__less-text', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-toggle-text', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-expand__more-toggle-text', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__more-text', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-expand__more-text', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/expand', '.ugb-expand__less-toggle-text', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-expand__less-toggle-text', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -86,10 +86,6 @@ function typeContent() {
 		cy.addBlock( 'ugb/feature-grid' ).as( 'featureGridBlock' )
 		registerBlockSnapshots( 'featureGridBlock' )
 
-		cy.openInspector( 'ugb/feature-grid', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Columns', 1 )
-
 		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__title', 'Hello World! 1' )
 			.assertBlockContent( '.ugb-feature-grid__title', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__description', 'Helloo World!! 12' )
@@ -97,6 +93,7 @@ function typeContent() {
 		cy.typeBlock( 'ugb/feature-grid', '.ugb-button--inner', 'Hellooo World!!! 123' )
 			.assertBlockContent( '.ugb-button--inner', 'Hellooo World!!! 123' )
 
+		cy.openInspector( 'ugb/feature-grid', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/feature-grid' )
 	} )
 }

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertAligns, responsiveAssertHelper, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertContainer, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertBlockTitleDescriptionContent, assertAligns, responsiveAssertHelper, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 import { range } from 'lodash'
@@ -96,6 +96,8 @@ function typeContent() {
 			.assertBlockContent( '.ugb-feature-grid__description', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/feature-grid', '.ugb-button--inner', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/feature-grid' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertAligns, responsiveAssertHelper, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 import { range } from 'lodash'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -82,33 +83,19 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/feature-grid' )
+		cy.addBlock( 'ugb/feature-grid' ).as( 'featureGridBlock' )
+		registerBlockSnapshots( 'featureGridBlock' )
 
 		cy.openInspector( 'ugb/feature-grid', 'Style' )
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
 		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-feature-grid__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__description', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-feature-grid__description', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/feature-grid', '.ugb-button--inner', 'Hello World! 1234' )
-
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-feature-grid' )
-				.find( '.ugb-feature-grid__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-feature-grid' )
-				.find( '.ugb-feature-grid__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-feature-grid' )
-				.find( '.ugb-button--inner' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -90,18 +90,18 @@ function typeContent() {
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
-		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-feature-grid__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-feature-grid__description', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/feature-grid', '.ugb-button--inner', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-feature-grid__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__description', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-feature-grid__description', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/feature-grid', '.ugb-button--inner', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-button--inner', 'Hellooo World!!! 123' )
 
 		assertBlockTitleDescriptionContent( 'ugb/feature-grid' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/feature-grid' ).as( 'featureGridBlock' )
@@ -306,7 +306,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	featureGridBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/feature-grid' ).as( 'featureGridBlock' )

--- a/cypress/integration/v2/blocks/feature-grid.spec.js
+++ b/cypress/integration/v2/blocks/feature-grid.spec.js
@@ -14,6 +14,7 @@ describe( 'Feature Grid Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -75,6 +76,40 @@ function switchDesign() {
 		'Upland Feature Grid',
 		'Yule Feature Grid',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/feature-grid' )
+
+		cy.openInspector( 'ugb/feature-grid', 'Style' )
+		cy.collapse( 'General' )
+		cy.adjust( 'Columns', 1 )
+
+		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/feature-grid', '.ugb-feature-grid__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/feature-grid', '.ugb-button--inner', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-feature-grid' )
+				.find( '.ugb-feature-grid__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-feature-grid' )
+				.find( '.ugb-feature-grid__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-feature-grid' )
+				.find( '.ugb-button--inner' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/feature.spec.js
+++ b/cypress/integration/v2/blocks/feature.spec.js
@@ -323,7 +323,7 @@ function styleTab( viewport, desktopOnly ) {
 	featureBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/feature' ).as( 'featureBlock' )

--- a/cypress/integration/v2/blocks/feature.spec.js
+++ b/cypress/integration/v2/blocks/feature.spec.js
@@ -123,16 +123,16 @@ function typeContent() {
 		cy.addBlock( 'ugb/feature' ).as( 'featureBlock' )
 		registerBlockSnapshots( 'featureBlock' )
 
-		cy.typeBlock( 'ugb/feature', '.ugb-feature__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-feature__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/feature', '.ugb-feature__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-feature__description', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/feature', '.ugb-button--inner', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/feature', '.ugb-feature__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-feature__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/feature', '.ugb-feature__description', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-feature__description', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/feature', '.ugb-button--inner', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-button--inner', 'Hellooo World!!! 123' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/feature' ).as( 'featureBlock' )
@@ -323,7 +323,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	featureBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/feature' ).as( 'featureBlock' )

--- a/cypress/integration/v2/blocks/feature.spec.js
+++ b/cypress/integration/v2/blocks/feature.spec.js
@@ -5,6 +5,7 @@ import { startCase } from 'lodash'
 import {
 	assertAligns, assertBlockBackground, assertBlockExist, assertSeparators, assertTypography, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -119,28 +120,15 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/feature' )
-		cy.typeBlock( 'ugb/feature', '.ugb-feature__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/feature', '.ugb-feature__description', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/feature', '.ugb-button--inner', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/feature' ).as( 'featureBlock' )
+		registerBlockSnapshots( 'featureBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-feature' )
-				.find( '.ugb-feature__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-feature' )
-				.find( '.ugb-feature__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-feature' )
-				.find( '.ugb-button--inner' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/feature', '.ugb-feature__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-feature__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/feature', '.ugb-feature__description', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-feature__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/feature', '.ugb-button--inner', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/feature.spec.js
+++ b/cypress/integration/v2/blocks/feature.spec.js
@@ -14,6 +14,7 @@ describe( 'Feature Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -112,6 +113,35 @@ function switchDesign() {
 		'Speck Feature',
 		'Upland Feature',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/feature' )
+		cy.typeBlock( 'ugb/feature', '.ugb-feature__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/feature', '.ugb-feature__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/feature', '.ugb-button--inner', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-feature' )
+				.find( '.ugb-feature__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-feature' )
+				.find( '.ugb-feature__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-feature' )
+				.find( '.ugb-button--inner' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -88,16 +88,16 @@ function typeContent() {
 		cy.addBlock( 'ugb/header' ).as( 'headerBlock' )
 		registerBlockSnapshots( 'headerBlock' )
 
-		cy.typeBlock( 'ugb/header', '.ugb-header__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-header__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/header', '.ugb-header__subtitle', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-header__subtitle', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/header', '.ugb-button--inner', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/header', '.ugb-header__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-header__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/header', '.ugb-header__subtitle', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-header__subtitle', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/header', '.ugb-button--inner', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-button--inner', 'Hellooo World!!! 123' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/header' ).as( 'headerBlock' )
@@ -357,7 +357,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	headerBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/header' ).as( 'headerBlock' )

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertAligns, assertBlockBackground, assertSeparators, responsiveAssertHelper, assertTypography, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -84,28 +85,15 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/header' )
-		cy.typeBlock( 'ugb/header', '.ugb-header__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/header', '.ugb-header__subtitle', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/header', '.ugb-button--inner', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/header' ).as( 'headerBlock' )
+		registerBlockSnapshots( 'headerBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-header' )
-				.find( '.ugb-header__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-header' )
-				.find( '.ugb-header__subtitle' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-header' )
-				.find( '.ugb-button--inner' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/header', '.ugb-header__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-header__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/header', '.ugb-header__subtitle', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-header__subtitle', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/header', '.ugb-button--inner', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -357,7 +357,7 @@ function styleTab( viewport, desktopOnly ) {
 	headerBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/header' ).as( 'headerBlock' )

--- a/cypress/integration/v2/blocks/header.spec.js
+++ b/cypress/integration/v2/blocks/header.spec.js
@@ -13,6 +13,7 @@ describe( 'Header', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -77,6 +78,35 @@ function switchDesign() {
 		'Upland Header',
 		'Yule Header',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/header' )
+		cy.typeBlock( 'ugb/header', '.ugb-header__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/header', '.ugb-header__subtitle', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/header', '.ugb-button--inner', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-header' )
+				.find( '.ugb-header__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-header' )
+				.find( '.ugb-header__subtitle' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-header' )
+				.find( '.ugb-button--inner' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/heading.spec.js
+++ b/cypress/integration/v2/blocks/heading.spec.js
@@ -37,14 +37,14 @@ function typeContent() {
 		cy.addBlock( 'ugb/heading' ).as( 'headingBlock' )
 		registerBlockSnapshots( 'headingBlock' )
 
-		cy.typeBlock( 'ugb/heading', '.ugb-heading__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-heading__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/heading', '.ugb-heading__subtitle', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-heading__subtitle', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/heading', '.ugb-heading__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-heading__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/heading', '.ugb-heading__subtitle', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-heading__subtitle', 'Helloo World!! 12' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/heading' ).as( 'headingBlock' )
@@ -185,7 +185,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	headingBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/heading' ).as( 'headingBlock' )

--- a/cypress/integration/v2/blocks/heading.spec.js
+++ b/cypress/integration/v2/blocks/heading.spec.js
@@ -5,6 +5,7 @@
 import {
 	assertBlockExist, blockErrorTest, assertAligns, registerTests, responsiveAssertHelper, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -33,23 +34,13 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/heading' )
-		cy.typeBlock( 'ugb/heading', '.ugb-heading__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/heading', '.ugb-heading__subtitle', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/heading' ).as( 'headingBlock' )
+		registerBlockSnapshots( 'headingBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-heading' )
-				.find( '.ugb-heading__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-heading' )
-				.find( '.ugb-heading__subtitle' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/heading', '.ugb-heading__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-heading__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/heading', '.ugb-heading__subtitle', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-heading__subtitle', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/heading.spec.js
+++ b/cypress/integration/v2/blocks/heading.spec.js
@@ -12,6 +12,7 @@ const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelp
 describe( 'Advanced Heading Block', registerTests( [
 	blockExist,
 	blockError,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -26,6 +27,30 @@ function blockExist() {
 
 function blockError() {
 	it( 'should not trigger block error when refreshing the page', blockErrorTest( 'ugb/heading' ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/heading' )
+		cy.typeBlock( 'ugb/heading', '.ugb-heading__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/heading', '.ugb-heading__subtitle', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-heading' )
+				.find( '.ugb-heading__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-heading' )
+				.find( '.ugb-heading__subtitle' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/heading.spec.js
+++ b/cypress/integration/v2/blocks/heading.spec.js
@@ -185,7 +185,7 @@ function styleTab( viewport, desktopOnly ) {
 	headingBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/heading' ).as( 'headingBlock' )

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, registerTests, responsiveAssertHelper, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -65,6 +65,9 @@ function typeContent() {
 
 		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Hello World! 1234' )
 			.assertBlockContent( '', 'Hello World! 1234' )
+
+		cy.openInspector( 'ugb/icon-list', 'Style' )
+		assertBlockTitleDescriptionContent( 'ugb/icon-list' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -62,10 +62,11 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/icon-list' )
+		cy.addBlock( 'ugb/icon-list' ).as( 'iconListBlock' )
+		registerBlockSnapshots( 'iconListBlock' )
 
-		cy.typeBlock( 'ugb/icon-list', '.ugb-block-content ul', 'Helloo World!! 12' )
-			.assertBlockContent( '', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-block-content ul', 'Helloo World!! 12' )
 
 		cy.openInspector( 'ugb/icon-list', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/icon-list' )

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -62,7 +62,7 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/icon-list' ).as( 'iconListBlock' )
+		cy.addBlock( 'ugb/icon-list' )
 
 		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Helloo World!! 12' )
 			.assertBlockContent( '', 'Helloo World!! 12' )
@@ -137,7 +137,7 @@ function styleTab( viewport, desktopOnly ) {
 	iconListBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/icon-list' ).as( 'iconListBlock' )

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -64,7 +64,7 @@ function typeContent() {
 		cy.newPage()
 		cy.addBlock( 'ugb/icon-list' )
 
-		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/icon-list', '.ugb-block-content ul', 'Helloo World!! 12' )
 			.assertBlockContent( '', 'Helloo World!! 12' )
 
 		cy.openInspector( 'ugb/icon-list', 'Style' )

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -61,17 +61,10 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/icon-list' )
-		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/icon-list' ).as( 'iconListBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-icon-list' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Hello World! 1234' )
+			.assertBlockContent( '', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -63,15 +64,15 @@ function typeContent() {
 		cy.newPage()
 		cy.addBlock( 'ugb/icon-list' ).as( 'iconListBlock' )
 
-		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Hello World! 1234' )
-			.assertBlockContent( '', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Helloo World!! 12' )
+			.assertBlockContent( '', 'Helloo World!! 12' )
 
 		cy.openInspector( 'ugb/icon-list', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/icon-list' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 
@@ -136,7 +137,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	iconListBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/icon-list' ).as( 'iconListBlock' )

--- a/cypress/integration/v2/blocks/icon-list.spec.js
+++ b/cypress/integration/v2/blocks/icon-list.spec.js
@@ -12,6 +12,7 @@ describe( 'Icon List Block', registerTests( [
 	blockExist,
 	blockError,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -54,6 +55,24 @@ function switchDesign() {
 		'Speck Icon List',
 		'Yule Icon List',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/icon-list' )
+		cy.typeBlock( 'ugb/icon-list', '.block-editor-rich-text__editable', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-icon-list' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/icon.spec.js
+++ b/cypress/integration/v2/blocks/icon.spec.js
@@ -50,14 +50,14 @@ function typeContent() {
 		cy.openInspector( 'ugb/icon', 'Style' )
 		cy.toggleStyle( 'Title' )
 
-		cy.typeBlock( 'ugb/icon', '.ugb-icon__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-icon__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/icon', '.ugb-icon__title', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-icon__title', 'Helloo World!! 12' )
 
 		assertBlockTitleDescriptionContent( 'ugb/icon' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/icon' ).as( 'iconBlock' )
@@ -227,7 +227,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	iconBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/icon' ).as( 'iconBlock' )

--- a/cypress/integration/v2/blocks/icon.spec.js
+++ b/cypress/integration/v2/blocks/icon.spec.js
@@ -227,7 +227,7 @@ function styleTab( viewport, desktopOnly ) {
 	iconBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/icon' ).as( 'iconBlock' )

--- a/cypress/integration/v2/blocks/icon.spec.js
+++ b/cypress/integration/v2/blocks/icon.spec.js
@@ -3,8 +3,9 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, registerTests, responsiveAssertHelper, assertTypography, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, assertAligns, assertBlockTitleDescription, assertBlockBackground, assertSeparators, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -13,6 +14,7 @@ describe( 'Icon Block', registerTests( [
 	blockExist,
 	blockError,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -36,6 +38,23 @@ function switchDesign() {
 		'Hue Icon',
 		'Lume Icon',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/icon' ).as( 'iconBlock' )
+		registerBlockSnapshots( 'iconBlock' )
+
+		cy.openInspector( 'ugb/icon', 'Style' )
+		cy.toggleStyle( 'Title' )
+
+		cy.typeBlock( 'ugb/icon', '.ugb-icon__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-icon__title', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/icon' )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/image-box.spec.js
+++ b/cypress/integration/v2/blocks/image-box.spec.js
@@ -14,6 +14,7 @@ describe( 'Image Box Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -64,6 +65,40 @@ function switchDesign() {
 		'Upland Image Box 1',
 		'Upland Image Box 2',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/image-box' )
+
+		cy.openInspector( 'ugb/image-box', 'Style' )
+		cy.collapse( 'General' )
+		cy.adjust( 'Columns', 1 )
+
+		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__subtitle', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__description', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-image-box' )
+				.find( '.ugb-image-box__subtitle' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-image-box' )
+				.find( '.ugb-image-box__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-image-box' )
+				.find( '.ugb-image-box__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly ) {

--- a/cypress/integration/v2/blocks/image-box.spec.js
+++ b/cypress/integration/v2/blocks/image-box.spec.js
@@ -79,12 +79,12 @@ function typeContent() {
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
-		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__subtitle', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-image-box__subtitle', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-image-box__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-image-box__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__subtitle', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-image-box__subtitle', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__title', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-image-box__title', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__description', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-image-box__description', 'Hellooo World!!! 123' )
 
 		assertBlockTitleDescriptionContent( 'ugb/image-box' )
 	} )
@@ -381,7 +381,7 @@ function styleTab( viewport, desktopOnly ) {
 	assertSeparators( { viewport } )
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/image-box' ).as( 'imageBoxBlock' )

--- a/cypress/integration/v2/blocks/image-box.spec.js
+++ b/cypress/integration/v2/blocks/image-box.spec.js
@@ -5,6 +5,7 @@ import { range } from 'lodash'
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -71,33 +72,19 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/image-box' )
+		cy.addBlock( 'ugb/image-box' ).as( 'imageBoxBlock' )
+		registerBlockSnapshots( 'imageBoxBlock' )
 
 		cy.openInspector( 'ugb/image-box', 'Style' )
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
 		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__subtitle', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-image-box__subtitle', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-image-box__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__description', 'Hello World! 1234' )
-
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-image-box' )
-				.find( '.ugb-image-box__subtitle' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-image-box' )
-				.find( '.ugb-image-box__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-image-box' )
-				.find( '.ugb-image-box__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+			.assertBlockContent( '.ugb-image-box__description', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/image-box.spec.js
+++ b/cypress/integration/v2/blocks/image-box.spec.js
@@ -75,10 +75,6 @@ function typeContent() {
 		cy.addBlock( 'ugb/image-box' ).as( 'imageBoxBlock' )
 		registerBlockSnapshots( 'imageBoxBlock' )
 
-		cy.openInspector( 'ugb/image-box', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Columns', 1 )
-
 		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__subtitle', 'Hello World! 1' )
 			.assertBlockContent( '.ugb-image-box__subtitle', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__title', 'Helloo World!! 12' )
@@ -86,6 +82,7 @@ function typeContent() {
 		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__description', 'Hellooo World!!! 123' )
 			.assertBlockContent( '.ugb-image-box__description', 'Hellooo World!!! 123' )
 
+		cy.openInspector( 'ugb/image-box', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/image-box' )
 	} )
 }
@@ -381,7 +378,7 @@ function styleTab( viewport, desktopOnly ) {
 	assertSeparators( { viewport } )
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/image-box' ).as( 'imageBoxBlock' )

--- a/cypress/integration/v2/blocks/image-box.spec.js
+++ b/cypress/integration/v2/blocks/image-box.spec.js
@@ -3,7 +3,7 @@
  */
 import { range } from 'lodash'
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertBlockTitleDescriptionContent, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
@@ -85,6 +85,8 @@ function typeContent() {
 			.assertBlockContent( '.ugb-image-box__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/image-box', '.ugb-image-box__description', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-image-box__description', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/image-box' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/notification.spec.js
+++ b/cypress/integration/v2/blocks/notification.spec.js
@@ -13,6 +13,7 @@ describe( 'Notification Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -51,6 +52,35 @@ function switchDesign() {
 		'Upland Notification',
 		'Yule Notification',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/notification' )
+		cy.typeBlock( 'ugb/notification', '.ugb-notification__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/notification', '.ugb-notification__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/notification', '.ugb-button--inner', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-notification' )
+				.find( '.ugb-notification__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-notification' )
+				.find( '.ugb-notification__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-notification' )
+				.find( '.ugb-button--inner' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/notification.spec.js
+++ b/cypress/integration/v2/blocks/notification.spec.js
@@ -315,7 +315,7 @@ function styleTab( viewport, desktopOnly ) {
 	notificationBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/notification' ).as( 'notificationBlock' )

--- a/cypress/integration/v2/blocks/notification.spec.js
+++ b/cypress/integration/v2/blocks/notification.spec.js
@@ -62,16 +62,16 @@ function typeContent() {
 		cy.addBlock( 'ugb/notification' ).as( 'notificationBlock' )
 		registerBlockSnapshots( 'notificationBlock' )
 
-		cy.typeBlock( 'ugb/notification', '.ugb-notification__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-notification__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/notification', '.ugb-notification__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-notification__description', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/notification', '.ugb-button--inner', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/notification', '.ugb-notification__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-notification__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/notification', '.ugb-notification__description', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-notification__description', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/notification', '.ugb-button--inner', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-button--inner', 'Hellooo World!!! 123' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/notification' ).as( 'notificationBlock' )
@@ -315,7 +315,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	notificationBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/notification' ).as( 'notificationBlock' )

--- a/cypress/integration/v2/blocks/notification.spec.js
+++ b/cypress/integration/v2/blocks/notification.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockBackground, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -58,28 +59,15 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/notification' )
-		cy.typeBlock( 'ugb/notification', '.ugb-notification__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/notification', '.ugb-notification__description', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/notification', '.ugb-button--inner', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/notification' ).as( 'notificationBlock' )
+		registerBlockSnapshots( 'notificationBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-notification' )
-				.find( '.ugb-notification__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-notification' )
-				.find( '.ugb-notification__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-notification' )
-				.find( '.ugb-button--inner' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/notification', '.ugb-notification__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-notification__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/notification', '.ugb-notification__description', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-notification__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/notification', '.ugb-button--inner', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/number-box.spec.js
+++ b/cypress/integration/v2/blocks/number-box.spec.js
@@ -72,16 +72,16 @@ function typeContent() {
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
-		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-number-box__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-number-box__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-number-box__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__description', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-number-box__description', 'Helloo World!! 12' )
 
 		assertBlockTitleDescriptionContent( 'ugb/number-box' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/number-box' ).as( 'numberBoxBlock' )
@@ -260,7 +260,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	numberBoxBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/number-box' ).as( 'numberBoxBlock' )

--- a/cypress/integration/v2/blocks/number-box.spec.js
+++ b/cypress/integration/v2/blocks/number-box.spec.js
@@ -68,15 +68,12 @@ function typeContent() {
 		cy.addBlock( 'ugb/number-box' ).as( 'numberBoxBlock' )
 		registerBlockSnapshots( 'numberBoxBlock' )
 
-		cy.openInspector( 'ugb/number-box', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Columns', 1 )
-
 		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__title', 'Hello World! 1' )
 			.assertBlockContent( '.ugb-number-box__title', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__description', 'Helloo World!! 12' )
 			.assertBlockContent( '.ugb-number-box__description', 'Helloo World!! 12' )
 
+		cy.openInspector( 'ugb/number-box', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/number-box' )
 	} )
 }

--- a/cypress/integration/v2/blocks/number-box.spec.js
+++ b/cypress/integration/v2/blocks/number-box.spec.js
@@ -15,6 +15,7 @@ describe( 'Number Box Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -57,6 +58,35 @@ function switchDesign() {
 		'Propel Number Box',
 		'Speck Number Box',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/number-box' )
+
+		cy.openInspector( 'ugb/number-box', 'Style' )
+		cy.collapse( 'General' )
+		cy.adjust( 'Columns', 1 )
+
+		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__description', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-number-box' )
+				.find( '.ugb-number-box__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-number-box' )
+				.find( '.ugb-number-box__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/number-box.spec.js
+++ b/cypress/integration/v2/blocks/number-box.spec.js
@@ -5,6 +5,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 import { startCase, range } from 'lodash'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
@@ -64,28 +65,17 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/number-box' )
+		cy.addBlock( 'ugb/number-box' ).as( 'numberBoxBlock' )
+		registerBlockSnapshots( 'numberBoxBlock' )
 
 		cy.openInspector( 'ugb/number-box', 'Style' )
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
 		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-number-box__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__description', 'Hello World! 1234' )
-
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-number-box' )
-				.find( '.ugb-number-box__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-number-box' )
-				.find( '.ugb-number-box__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+			.assertBlockContent( '.ugb-number-box__description', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/number-box.spec.js
+++ b/cypress/integration/v2/blocks/number-box.spec.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertContainer, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 import { startCase, range } from 'lodash'
@@ -76,6 +76,8 @@ function typeContent() {
 			.assertBlockContent( '.ugb-number-box__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/number-box', '.ugb-number-box__description', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-number-box__description', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/number-box' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/pricing-box.spec.js
+++ b/cypress/integration/v2/blocks/pricing-box.spec.js
@@ -5,6 +5,7 @@ import { range, startCase } from 'lodash'
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertContainer, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -68,53 +69,27 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/pricing-box' )
+		cy.addBlock( 'ugb/pricing-box' ).as( 'pricingBoxBlock' )
+		registerBlockSnapshots( 'pricingBoxBlock' )
 
 		cy.openInspector( 'ugb/pricing-box', 'Style' )
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-pricing-box__title', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price-prefix', 'P' )
+			.assertBlockContent( '.ugb-pricing-box__price-prefix', 'P' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price', '1234' )
+			.assertBlockContent( '.ugb-pricing-box__price', '1234' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price-suffix', '1234' )
+			.assertBlockContent( '.ugb-pricing-box__price-suffix', '1234' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__subprice', '1234' )
+			.assertBlockContent( '.ugb-pricing-box__subprice', '1234' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-button--inner', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__description', 'Hello World! 1234' )
-
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-pricing-box' )
-				.find( '.ugb-pricing-box__title' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-pricing-box' )
-				.find( '.ugb-pricing-box__price-prefix' )
-				.contains( 'P' )
-				.should( 'exist' )
-			cy.get( '.ugb-pricing-box' )
-				.find( '.ugb-pricing-box__price' )
-				.contains( '1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-pricing-box' )
-				.find( '.ugb-pricing-box__price-suffix' )
-				.contains( '1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-pricing-box' )
-				.find( '.ugb-pricing-box__subprice' )
-				.contains( '1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-pricing-box' )
-				.find( '.ugb-button--inner' )
-				.contains( '1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-pricing-box' )
-				.find( '.ugb-pricing-box__description' )
-				.contains( '1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+			.assertBlockContent( '.ugb-pricing-box__description', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/pricing-box.spec.js
+++ b/cypress/integration/v2/blocks/pricing-box.spec.js
@@ -3,7 +3,7 @@
  */
 import { range, startCase } from 'lodash'
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertContainer, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAligns, assertContainer, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
@@ -90,6 +90,8 @@ function typeContent() {
 			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__description', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-pricing-box__description', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/pricing-box' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/pricing-box.spec.js
+++ b/cypress/integration/v2/blocks/pricing-box.spec.js
@@ -76,26 +76,26 @@ function typeContent() {
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
-		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-pricing-box__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-pricing-box__title', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price-prefix', 'P' )
 			.assertBlockContent( '.ugb-pricing-box__price-prefix', 'P' )
-		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price', '1234' )
-			.assertBlockContent( '.ugb-pricing-box__price', '1234' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price', '12' )
+			.assertBlockContent( '.ugb-pricing-box__price', '12' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price-suffix', '1234' )
 			.assertBlockContent( '.ugb-pricing-box__price-suffix', '1234' )
-		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__subprice', '1234' )
-			.assertBlockContent( '.ugb-pricing-box__subprice', '1234' )
-		cy.typeBlock( 'ugb/pricing-box', '.ugb-button--inner', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-button--inner', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-pricing-box__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__subprice', '123456' )
+			.assertBlockContent( '.ugb-pricing-box__subprice', '123456' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-button--inner', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-button--inner', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__description', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-pricing-box__description', 'Hellooo World!!! 123' )
 
 		assertBlockTitleDescriptionContent( 'ugb/pricing-box' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/pricing-box' ).as( 'pricingBoxBlock' )
@@ -400,7 +400,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	pricingBoxBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/pricing-box' ).as( 'pricingBoxBlock' )

--- a/cypress/integration/v2/blocks/pricing-box.spec.js
+++ b/cypress/integration/v2/blocks/pricing-box.spec.js
@@ -14,6 +14,7 @@ describe( 'Pricing Box Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -61,6 +62,60 @@ function switchDesign() {
 		'Upland Pricing Box',
 		'Yule Pricing Box',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/pricing-box' )
+
+		cy.openInspector( 'ugb/pricing-box', 'Style' )
+		cy.collapse( 'General' )
+		cy.adjust( 'Columns', 1 )
+
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price-prefix', 'P' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price', '1234' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price-suffix', '1234' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__subprice', '1234' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-button--inner', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__description', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-pricing-box' )
+				.find( '.ugb-pricing-box__title' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-pricing-box' )
+				.find( '.ugb-pricing-box__price-prefix' )
+				.contains( 'P' )
+				.should( 'exist' )
+			cy.get( '.ugb-pricing-box' )
+				.find( '.ugb-pricing-box__price' )
+				.contains( '1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-pricing-box' )
+				.find( '.ugb-pricing-box__price-suffix' )
+				.contains( '1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-pricing-box' )
+				.find( '.ugb-pricing-box__subprice' )
+				.contains( '1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-pricing-box' )
+				.find( '.ugb-button--inner' )
+				.contains( '1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-pricing-box' )
+				.find( '.ugb-pricing-box__description' )
+				.contains( '1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/pricing-box.spec.js
+++ b/cypress/integration/v2/blocks/pricing-box.spec.js
@@ -72,10 +72,6 @@ function typeContent() {
 		cy.addBlock( 'ugb/pricing-box' ).as( 'pricingBoxBlock' )
 		registerBlockSnapshots( 'pricingBoxBlock' )
 
-		cy.openInspector( 'ugb/pricing-box', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Columns', 1 )
-
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__title', 'Hello World! 1' )
 			.assertBlockContent( '.ugb-pricing-box__title', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__price-prefix', 'P' )
@@ -91,6 +87,7 @@ function typeContent() {
 		cy.typeBlock( 'ugb/pricing-box', '.ugb-pricing-box__description', 'Hellooo World!!! 123' )
 			.assertBlockContent( '.ugb-pricing-box__description', 'Hellooo World!!! 123' )
 
+		cy.openInspector( 'ugb/pricing-box', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/pricing-box' )
 	} )
 }

--- a/cypress/integration/v2/blocks/separator.spec.js
+++ b/cypress/integration/v2/blocks/separator.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchLayouts, registerTests, responsiveAssertHelper, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -45,7 +46,7 @@ function switchLayout() {
 	] ) )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/separator' ).as( 'separatorBlock' )
@@ -272,7 +273,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	separatorBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/separator' ).as( 'separatorBlock' )

--- a/cypress/integration/v2/blocks/separator.spec.js
+++ b/cypress/integration/v2/blocks/separator.spec.js
@@ -273,7 +273,7 @@ function styleTab( viewport, desktopOnly ) {
 	separatorBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/separator' ).as( 'separatorBlock' )

--- a/cypress/integration/v2/blocks/spacer.spec.js
+++ b/cypress/integration/v2/blocks/spacer.spec.js
@@ -164,7 +164,7 @@ function styleTab( viewport, desktopOnly ) {
 	spacerBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/spacer' ).as( 'spacerBlock' )

--- a/cypress/integration/v2/blocks/spacer.spec.js
+++ b/cypress/integration/v2/blocks/spacer.spec.js
@@ -8,6 +8,7 @@ import {
 import {
 	assertBlockExist, blockErrorTest, assertSeparators, registerTests, responsiveAssertHelper, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -31,7 +32,7 @@ function blockError() {
 	it( 'should not trigger block error when refreshing the page', blockErrorTest( 'ugb/spacer' ) )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/spacer' ).as( 'spacerBlock' )
@@ -163,7 +164,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	spacerBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/spacer' ).as( 'spacerBlock' )

--- a/cypress/integration/v2/blocks/team-member.spec.js
+++ b/cypress/integration/v2/blocks/team-member.spec.js
@@ -3,7 +3,7 @@
  */
 import { range, startCase } from 'lodash'
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertContainer, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAligns, assertContainer, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
@@ -80,6 +80,8 @@ function typeContent() {
 			.assertBlockContent( '.ugb-team-member__position', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__description', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-team-member__description', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/team-member' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/team-member.spec.js
+++ b/cypress/integration/v2/blocks/team-member.spec.js
@@ -74,18 +74,18 @@ function typeContent() {
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
-		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__name', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-team-member__name', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__position', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-team-member__position', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__description', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-team-member__description', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__name', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-team-member__name', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__position', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-team-member__position', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__description', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-team-member__description', 'Hellooo World!!! 123' )
 
 		assertBlockTitleDescriptionContent( 'ugb/team-member' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/team-member' ).as( 'teamMemberBlock' )
@@ -318,7 +318,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	teamMemberBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/team-member' ).as( 'teamMemberBlock' )

--- a/cypress/integration/v2/blocks/team-member.spec.js
+++ b/cypress/integration/v2/blocks/team-member.spec.js
@@ -13,6 +13,7 @@ describe( 'Team Member Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -59,6 +60,40 @@ function switchDesign() {
 		'Seren Team Member 2',
 		'Upland Team Member',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/team-member' )
+
+		cy.openInspector( 'ugb/team-member', 'Style' )
+		cy.collapse( 'General' )
+		cy.adjust( 'Columns', 1 )
+
+		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__name', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__position', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__description', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-team-member' )
+				.find( '.ugb-team-member__name' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-team-member' )
+				.find( '.ugb-team-member__position' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-team-member' )
+				.find( '.ugb-team-member__description' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/team-member.spec.js
+++ b/cypress/integration/v2/blocks/team-member.spec.js
@@ -5,6 +5,7 @@ import { range, startCase } from 'lodash'
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertContainer, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -66,33 +67,19 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/team-member' )
+		cy.addBlock( 'ugb/team-member' ).as( 'teamMemberBlock' )
+		registerBlockSnapshots( 'teamMemberBlock' )
 
 		cy.openInspector( 'ugb/team-member', 'Style' )
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
 		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__name', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-team-member__name', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__position', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-team-member__position', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__description', 'Hello World! 1234' )
-
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-team-member' )
-				.find( '.ugb-team-member__name' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-team-member' )
-				.find( '.ugb-team-member__position' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-team-member' )
-				.find( '.ugb-team-member__description' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+			.assertBlockContent( '.ugb-team-member__description', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/team-member.spec.js
+++ b/cypress/integration/v2/blocks/team-member.spec.js
@@ -70,10 +70,6 @@ function typeContent() {
 		cy.addBlock( 'ugb/team-member' ).as( 'teamMemberBlock' )
 		registerBlockSnapshots( 'teamMemberBlock' )
 
-		cy.openInspector( 'ugb/team-member', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Columns', 1 )
-
 		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__name', 'Hello World! 1' )
 			.assertBlockContent( '.ugb-team-member__name', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__position', 'Helloo World!! 12' )
@@ -81,6 +77,7 @@ function typeContent() {
 		cy.typeBlock( 'ugb/team-member', '.ugb-team-member__description', 'Hellooo World!!! 123' )
 			.assertBlockContent( '.ugb-team-member__description', 'Hellooo World!!! 123' )
 
+		cy.openInspector( 'ugb/team-member', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/team-member' )
 	} )
 }

--- a/cypress/integration/v2/blocks/testimonial.spec.js
+++ b/cypress/integration/v2/blocks/testimonial.spec.js
@@ -76,18 +76,18 @@ function typeContent() {
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
-		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__body', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-testimonial__body', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__name', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-testimonial__name', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__position', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-testimonial__position', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__body', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-testimonial__body', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__name', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-testimonial__name', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__position', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-testimonial__position', 'Hellooo World!!! 123' )
 
 		assertBlockTitleDescriptionContent( 'ugb/testimonial' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/testimonial' ).as( 'testimonialBlock' )
@@ -262,7 +262,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	testimonialBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/testimonial' ).as( 'testimonialBlock' )

--- a/cypress/integration/v2/blocks/testimonial.spec.js
+++ b/cypress/integration/v2/blocks/testimonial.spec.js
@@ -3,7 +3,7 @@
  */
 import { range } from 'lodash'
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertContainer, assertAdvancedTab,
+	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
 import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
@@ -82,6 +82,8 @@ function typeContent() {
 			.assertBlockContent( '.ugb-testimonial__name', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__position', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-testimonial__position', 'Hello World! 1234' )
+
+		assertBlockTitleDescriptionContent( 'ugb/testimonial' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/testimonial.spec.js
+++ b/cypress/integration/v2/blocks/testimonial.spec.js
@@ -14,6 +14,7 @@ describe( 'Testimonial Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -61,6 +62,40 @@ function switchDesign() {
 		'Upland Testimonial',
 		'Yule Testimonial',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/testimonial' )
+
+		cy.openInspector( 'ugb/testimonial', 'Style' )
+		cy.collapse( 'General' )
+		cy.adjust( 'Columns', 1 )
+
+		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__body', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__name', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__position', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-testimonial' )
+				.find( '.ugb-testimonial__body' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-testimonial' )
+				.find( '.ugb-testimonial__name' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.get( '.ugb-testimonial' )
+				.find( '.ugb-testimonial__position' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/testimonial.spec.js
+++ b/cypress/integration/v2/blocks/testimonial.spec.js
@@ -5,6 +5,7 @@ import { range } from 'lodash'
 import {
 	assertBlockExist, blockErrorTest, switchDesigns, switchLayouts, registerTests, responsiveAssertHelper, assertAligns, assertTypography, assertBlockTitleDescription, assertBlockBackground, assertSeparators, assertContainer, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -68,33 +69,19 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/testimonial' )
+		cy.addBlock( 'ugb/testimonial' ).as( 'testimonialBlock' )
+		registerBlockSnapshots( 'testimonialBlock' )
 
 		cy.openInspector( 'ugb/testimonial', 'Style' )
 		cy.collapse( 'General' )
 		cy.adjust( 'Columns', 1 )
 
 		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__body', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-testimonial__body', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__name', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-testimonial__name', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__position', 'Hello World! 1234' )
-
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-testimonial' )
-				.find( '.ugb-testimonial__body' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-testimonial' )
-				.find( '.ugb-testimonial__name' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.get( '.ugb-testimonial' )
-				.find( '.ugb-testimonial__position' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+			.assertBlockContent( '.ugb-testimonial__position', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/testimonial.spec.js
+++ b/cypress/integration/v2/blocks/testimonial.spec.js
@@ -72,10 +72,6 @@ function typeContent() {
 		cy.addBlock( 'ugb/testimonial' ).as( 'testimonialBlock' )
 		registerBlockSnapshots( 'testimonialBlock' )
 
-		cy.openInspector( 'ugb/testimonial', 'Style' )
-		cy.collapse( 'General' )
-		cy.adjust( 'Columns', 1 )
-
 		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__body', 'Hello World! 1' )
 			.assertBlockContent( '.ugb-testimonial__body', 'Hello World! 1' )
 		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__name', 'Helloo World!! 12' )
@@ -83,6 +79,7 @@ function typeContent() {
 		cy.typeBlock( 'ugb/testimonial', '.ugb-testimonial__position', 'Hellooo World!!! 123' )
 			.assertBlockContent( '.ugb-testimonial__position', 'Hellooo World!!! 123' )
 
+		cy.openInspector( 'ugb/testimonial', 'Style' )
 		assertBlockTitleDescriptionContent( 'ugb/testimonial' )
 	} )
 }

--- a/cypress/integration/v2/blocks/text.spec.js
+++ b/cypress/integration/v2/blocks/text.spec.js
@@ -68,6 +68,14 @@ function typeContent() {
 		cy.addBlock( 'ugb/text' ).as( 'textBlock' )
 		registerBlockSnapshots( 'textBlock' )
 
+		cy.openInspector( 'ugb/text', 'Style' )
+		cy.toggleStyle( 'Title' )
+		cy.toggleStyle( 'Subtitle' )
+
+		cy.typeBlock( 'ugb/text', '.ugb-text__title', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-text__title', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/text', '.ugb-text__subtitle', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-text__subtitle', 'Hello World! 1234' )
 		cy.typeBlock( 'ugb/text', '.ugb-text__text-1', 'Hello World! 1234' )
 			.assertBlockContent( '.ugb-text__text-1', 'Hello World! 1234' )
 	} )

--- a/cypress/integration/v2/blocks/text.spec.js
+++ b/cypress/integration/v2/blocks/text.spec.js
@@ -4,6 +4,7 @@
 import {
 	assertBlockExist, blockErrorTest, switchLayouts, switchDesigns, assertAligns, assertBlockBackground, assertSeparators, registerTests, responsiveAssertHelper, assertTypography, assertAdvancedTab,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -64,18 +65,11 @@ function typeContent() {
 	it( 'should allow typing in the block', () => {
 		cy.setupWP()
 		cy.newPage()
-		cy.addBlock( 'ugb/text' )
-		cy.typeBlock( 'ugb/text', '.ugb-text__text-1', 'Hello World! 1234' )
+		cy.addBlock( 'ugb/text' ).as( 'textBlock' )
+		registerBlockSnapshots( 'textBlock' )
 
-		cy.publish()
-		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
-			cy.visit( previewUrl )
-			cy.get( '.ugb-text' )
-				.find( '.ugb-text__text-1' )
-				.contains( 'Hello World! 1234' )
-				.should( 'exist' )
-			cy.visit( editorUrl )
-		} )
+		cy.typeBlock( 'ugb/text', '.ugb-text__text-1', 'Hello World! 1234' )
+			.assertBlockContent( '.ugb-text__text-1', 'Hello World! 1234' )
 	} )
 }
 

--- a/cypress/integration/v2/blocks/text.spec.js
+++ b/cypress/integration/v2/blocks/text.spec.js
@@ -235,7 +235,7 @@ function styleTab( viewport, desktopOnly ) {
 	textBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/text' ).as( 'textBlock' )

--- a/cypress/integration/v2/blocks/text.spec.js
+++ b/cypress/integration/v2/blocks/text.spec.js
@@ -13,6 +13,7 @@ describe( 'Advanced Text Block', registerTests( [
 	blockError,
 	switchLayout,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -57,6 +58,25 @@ function switchDesign() {
 		'Proact Advanced Text 2',
 		'Seren Advanced Text',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/text' )
+		cy.typeBlock( 'ugb/text', '.ugb-text__text-1', 'Hello World! 1234' )
+
+		cy.publish()
+		cy.getPostUrls().then( ( { editorUrl, previewUrl } ) => {
+			cy.visit( previewUrl )
+			cy.get( '.ugb-text' )
+				.find( '.ugb-text__text-1' )
+				.contains( 'Hello World! 1234' )
+				.should( 'exist' )
+			cy.visit( editorUrl )
+		} )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/text.spec.js
+++ b/cypress/integration/v2/blocks/text.spec.js
@@ -72,16 +72,16 @@ function typeContent() {
 		cy.toggleStyle( 'Title' )
 		cy.toggleStyle( 'Subtitle' )
 
-		cy.typeBlock( 'ugb/text', '.ugb-text__title', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-text__title', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/text', '.ugb-text__subtitle', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-text__subtitle', 'Hello World! 1234' )
-		cy.typeBlock( 'ugb/text', '.ugb-text__text-1', 'Hello World! 1234' )
-			.assertBlockContent( '.ugb-text__text-1', 'Hello World! 1234' )
+		cy.typeBlock( 'ugb/text', '.ugb-text__title', 'Hello World! 1' )
+			.assertBlockContent( '.ugb-text__title', 'Hello World! 1' )
+		cy.typeBlock( 'ugb/text', '.ugb-text__subtitle', 'Helloo World!! 12' )
+			.assertBlockContent( '.ugb-text__subtitle', 'Helloo World!! 12' )
+		cy.typeBlock( 'ugb/text', '.ugb-text__text-1', 'Hellooo World!!! 123' )
+			.assertBlockContent( '.ugb-text__text-1', 'Hellooo World!!! 123' )
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/text' ).as( 'textBlock' )
@@ -235,7 +235,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	textBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/text' ).as( 'textBlock' )

--- a/cypress/integration/v2/blocks/video-popup.spec.js
+++ b/cypress/integration/v2/blocks/video-popup.spec.js
@@ -3,8 +3,9 @@
  * External dependencies
  */
 import {
-	assertBlockExist, blockErrorTest, switchDesigns, registerTests, responsiveAssertHelper, assertAdvancedTab, assertContainer, assertBlockTitleDescription, assertBlockBackground, assertSeparators,
+	assertBlockExist, blockErrorTest, switchDesigns, registerTests, assertBlockTitleDescriptionContent, responsiveAssertHelper, assertAdvancedTab, assertContainer, assertBlockTitleDescription, assertBlockBackground, assertSeparators,
 } from '~stackable-e2e/helpers'
+import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 const [ desktopStyle, tabletStyle, mobileStyle ] = responsiveAssertHelper( styleTab )
 const [ desktopAdvanced, tabletAdvanced, mobileAdvanced ] = responsiveAssertHelper( advancedTab, { tab: 'Advanced' } )
@@ -13,6 +14,7 @@ describe( 'Video Popup Block', registerTests( [
 	blockExist,
 	blockError,
 	switchDesign,
+	typeContent,
 	desktopStyle,
 	tabletStyle,
 	mobileStyle,
@@ -44,6 +46,18 @@ function switchDesign() {
 		'Peplum Video Popup',
 		'Speck Video Popup',
 	] ) )
+}
+
+function typeContent() {
+	it( 'should allow typing in the block', () => {
+		cy.setupWP()
+		cy.newPage()
+		cy.addBlock( 'ugb/video-popup' ).as( 'videoPopupBlock' )
+		registerBlockSnapshots( 'videoPopupBlock' )
+		cy.openInspector( 'ugb/video-popup', 'Style' )
+
+		assertBlockTitleDescriptionContent( 'ugb/video-popup' )
+	} )
 }
 
 function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {

--- a/cypress/integration/v2/blocks/video-popup.spec.js
+++ b/cypress/integration/v2/blocks/video-popup.spec.js
@@ -127,7 +127,7 @@ function styleTab( viewport, desktopOnly ) {
 	videoPopupBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly ) {
+function advancedTab( viewport ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/video-popup' ).as( 'videoPopupBlock' )

--- a/cypress/integration/v2/blocks/video-popup.spec.js
+++ b/cypress/integration/v2/blocks/video-popup.spec.js
@@ -60,7 +60,7 @@ function typeContent() {
 	} )
 }
 
-function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function styleTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/video-popup' ).as( 'videoPopupBlock' )
@@ -127,7 +127,7 @@ function styleTab( viewport, desktopOnly, registerBlockSnapshots ) {
 	videoPopupBlock.assertFrontendStyles()
 }
 
-function advancedTab( viewport, desktopOnly, registerBlockSnapshots ) {
+function advancedTab( viewport, desktopOnly ) {
 	cy.setupWP()
 	cy.newPage()
 	cy.addBlock( 'ugb/video-popup' ).as( 'videoPopupBlock' )

--- a/cypress/support/gutenberg/commands/assertions.js
+++ b/cypress/support/gutenberg/commands/assertions.js
@@ -386,19 +386,14 @@ export function assertBlockContent( subject, customSelector = '', expectedValue 
 							cy.wait( delay )
 
 							cy.document().then( doc => {
-								const element = doc.querySelector( selector )
-								if ( element ) {
-									assert.isTrue(
-										! isEmpty( customSelector !== ''
-											? cy.get( selector )
-												.find( `${ customSelector }` )
-												.contains( `${ expectedValue }` )
-											: cy.get( selector )
-												.contains( `${ expectedValue }` ) )
-										,
-										`${ customSelector } must have content '${ expectedValue }' in Frontend'`
-									)
-								}
+								const blockElement = doc.querySelector( `${ selector }${ customSelector }` ) || doc.querySelector( `${ selector } ${ customSelector }` )
+								cy.log( blockElement )
+								// if ( blockElement ) {
+								// 	assert.isTrue(
+								// 		blockElement.textContent === expectedValue,
+								// 		`${ customSelector } must have content '${ expectedValue }' in Frontend'`
+								// 	)
+								// }
 
 								cy.visit( editorUrl )
 								cy.wp().then( _wp => {

--- a/cypress/support/gutenberg/commands/assertions.js
+++ b/cypress/support/gutenberg/commands/assertions.js
@@ -368,7 +368,7 @@ export function assertBlockContent( subject, customSelector = '', expectedValue 
 		const blockPath = getBlockStringPath( wp.data.select( 'core/block-editor' ).getBlocks(), subject.data( 'block' ) )
 
 		cy.getBlockAttributes().then( attributes => {
-			const selector = `${ attributes.className }`
+			const selector = `.${ attributes.className }`
 			cy
 				.get( subject )
 				.then( $block => {
@@ -386,14 +386,14 @@ export function assertBlockContent( subject, customSelector = '', expectedValue 
 							cy.wait( delay )
 
 							cy.document().then( doc => {
-								const element = doc.querySelector( `.${ selector }` )
+								const element = doc.querySelector( selector )
 								if ( element ) {
 									assert.isTrue(
 										! isEmpty( customSelector !== ''
-											? cy.get( `.${ selector }` )
+											? cy.get( selector )
 												.find( `${ customSelector }` )
 												.contains( `${ expectedValue }` )
-											: cy.get( `.${ selector }` )
+											: cy.get( selector )
 												.contains( `${ expectedValue }` ) )
 										,
 										`${ customSelector } must have content '${ expectedValue }' in Frontend'`

--- a/cypress/support/gutenberg/commands/assertions.js
+++ b/cypress/support/gutenberg/commands/assertions.js
@@ -387,13 +387,12 @@ export function assertBlockContent( subject, customSelector = '', expectedValue 
 
 							cy.document().then( doc => {
 								const blockElement = doc.querySelector( `${ selector }${ customSelector }` ) || doc.querySelector( `${ selector } ${ customSelector }` )
-								cy.log( blockElement )
-								// if ( blockElement ) {
-								// 	assert.isTrue(
-								// 		blockElement.textContent === expectedValue,
-								// 		`${ customSelector } must have content '${ expectedValue }' in Frontend'`
-								// 	)
-								// }
+								if ( blockElement ) {
+									assert.isTrue(
+										blockElement.textContent === expectedValue,
+										`${ customSelector } must have content '${ expectedValue }' in Frontend'`
+									)
+								}
 
 								cy.visit( editorUrl )
 								cy.wp().then( _wp => {

--- a/cypress/support/gutenberg/commands/blocks.js
+++ b/cypress/support/gutenberg/commands/blocks.js
@@ -107,9 +107,6 @@ export function typeBlock( subject, contentSelector = '', content = '', customSe
 	)
 		.click( { force: true } )
 		.type( `{selectall}${ content }`, { force: true } )
-		.then( $element => {
-			return expect( $element ).to.contain( content )
-		} )
 
 	if ( content[ 0 ] !== '/' ) {
 		cy.selectBlock( subject, customSelector )

--- a/cypress/support/gutenberg/commands/blocks.js
+++ b/cypress/support/gutenberg/commands/blocks.js
@@ -107,6 +107,7 @@ export function typeBlock( subject, contentSelector = '', content = '', customSe
 		? cy.selectBlock( subject, customSelector ).find( contentSelector )
 		: cy.selectBlock( subject, customSelector )
 	)
+		.first()
 		.click( { force: true } )
 		.type( `{selectall}${ content }`, { force: true } )
 

--- a/cypress/support/gutenberg/plugins/blockSnapshots.js
+++ b/cypress/support/gutenberg/plugins/blockSnapshots.js
@@ -216,9 +216,10 @@ export const registerBlockSnapshots = alias => {
 			cy.wp().then( wp => {
 				const block = wp.data.select( 'core/block-editor' ).getBlock( subject.data( 'block' ) )
 				const saveElement = createElementFromHTMLString( wp.blocks.getBlockContent( block ) )
+				const parsedClassList = Array.from( saveElement.classList ).map( _class => `.${ _class }` ).join( '' )
 
 				assert.isTrue(
-					saveElement.textContent === expectedValue || saveElement.querySelector( customSelector ).textContent === expectedValue,
+					( parsedClassList.match( customSelector ) ? saveElement : saveElement.querySelector( customSelector ) ).textContent === expectedValue,
 					`${ customSelector } must have content '${ expectedValue }' in Frontend'`
 				)
 			} )

--- a/cypress/support/gutenberg/plugins/blockSnapshots.js
+++ b/cypress/support/gutenberg/plugins/blockSnapshots.js
@@ -216,21 +216,11 @@ export const registerBlockSnapshots = alias => {
 			cy.wp().then( wp => {
 				const block = wp.data.select( 'core/block-editor' ).getBlock( subject.data( 'block' ) )
 				const saveElement = createElementFromHTMLString( wp.blocks.getBlockContent( block ) )
-				const parsedClassList = Array.from( saveElement.classList ).map( _class => `.${ _class }` ).join( '' )
 
-				if ( parsedClassList.match( customSelector ) ) {
-					// Check if we're asserting the parent element.
-					assert.isTrue(
-						saveElement.textContent === expectedValue,
-						`${ customSelector } must have content '${ expectedValue }' in Frontend'`
-					)
-				} else {
-					// Otherwise, search the element
-					assert.isTrue(
-						saveElement.querySelector( customSelector ).textContent === expectedValue,
-						`${ customSelector } must have content '${ expectedValue }' in Frontend'`
-					)
-				}
+				assert.isTrue(
+					saveElement.textContent === expectedValue || saveElement.querySelector( customSelector ).textContent === expectedValue,
+					`${ customSelector } must have content '${ expectedValue }' in Frontend'`
+				)
 			} )
 
 			originalFn( ...[ ...passedArgs, optionsToPass ] )

--- a/cypress/support/gutenberg/plugins/blockSnapshots.js
+++ b/cypress/support/gutenberg/plugins/blockSnapshots.js
@@ -26,7 +26,7 @@
 import {
 	createElementFromHTMLString,
 } from '../util'
-import { _assertComputedStyle, _assertFrontendBlockContent } from '../commands/assertions'
+import { _assertComputedStyle } from '../commands/assertions'
 
 /**
  * External dependencies
@@ -162,39 +162,6 @@ class BlockSnapshots {
 							cy.viewport( Cypress.config( 'viewportWidth' ), Cypress.config( 'viewportHeight' ) )
 						} )
 					} )
-				} )
-			} )
-		} )
-	}
-
-	/**
-	 * Enqueue all stubbed html contents to the frontend.
-	 * Individually assert its content.
-	 */
-	 assertFrontendContent() {
-		const self = this
-		cy.get( `@${ self.alias }.stubbedContentAssertions` ).then( $stubbedContent => {
-			cy.get( `@${ self.alias }.contentSnapshots` ).then( $contentSnapshots => {
-				// Combine all stubbed styles and content snapshots into one array.
-				const combinedStubbed = $contentSnapshots.map( ( htmlContent, index ) => {
-					return {
-						htmlContent,
-						customSelector: $stubbedContent[ index ].customSelector,
-						expectedValue: $stubbedContent[ index ].content,
-					}
-				} )
-
-				if ( ! combinedStubbed.length ) {
-					return
-				}
-
-				combinedStubbed.forEach( combinedStubbedContent => {
-					const {
-						htmlContent, customSelector, expectedValue,
-					} = combinedStubbedContent
-
-					// Assert Frontend Content
-					_assertFrontendBlockContent( htmlContent, customSelector, expectedValue )
 				} )
 			} )
 		} )

--- a/cypress/support/stackable/commands/assertions.js
+++ b/cypress/support/stackable/commands/assertions.js
@@ -7,6 +7,7 @@ import { getActiveTab } from '../util'
  * Exernal dependencies
  */
 import { last, startCase } from 'lodash'
+import { withInspectorTabMemory } from '~gutenberg-e2e/util'
 
 /**
  * Overwrite Gutenberg commands
@@ -27,18 +28,4 @@ Cypress.Commands.overwrite( 'assertComputedStyle', ( originalFn, ...args ) => {
 	} )
 } )
 
-Cypress.Commands.overwrite( 'assertBlockContent', ( originalFn, ...args ) => {
-	getActiveTab( tab => {
-		originalFn( ...args )
-
-		// This is for Stackable only.
-		// After asserting the frontend, go back to the previous editor state.
-		if ( ( args.length === 4 &&
-				( last( args ).assertFrontend === undefined ||
-				last( args ).assertFrontend ) ) ||
-			args.length === 3 ) {
-			cy.openSidebar( 'Settings' )
-			cy.get( `button[aria-label="${ startCase( tab ) } Tab"]` ).click( { force: true } )
-		}
-	} )
-} )
+Cypress.Commands.overwrite( 'assertBlockContent', withInspectorTabMemory( { argumentLength: 4 } ) )

--- a/cypress/support/stackable/commands/assertions.js
+++ b/cypress/support/stackable/commands/assertions.js
@@ -26,3 +26,19 @@ Cypress.Commands.overwrite( 'assertComputedStyle', ( originalFn, ...args ) => {
 		}
 	} )
 } )
+
+Cypress.Commands.overwrite( 'assertBlockContent', ( originalFn, ...args ) => {
+	getActiveTab( tab => {
+		originalFn( ...args )
+
+		// This is for Stackable only.
+		// After asserting the frontend, go back to the previous editor state.
+		if ( ( args.length === 4 &&
+				( last( args ).assertFrontend === undefined ||
+				last( args ).assertFrontend ) ) ||
+			args.length === 3 ) {
+			cy.openSidebar( 'Settings' )
+			cy.get( `button[aria-label="${ startCase( tab ) } Tab"]` ).click( { force: true } )
+		}
+	} )
+} )

--- a/cypress/support/stackable/helpers/index.js
+++ b/cypress/support/stackable/helpers/index.js
@@ -4,7 +4,6 @@
 import {
 	lowerCase, isEmpty,
 } from 'lodash'
-import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
 
 /**
  * Export Block Module assertions.
@@ -171,11 +170,11 @@ export const responsiveAssertHelper = ( callback = () => {}, options = {} ) => {
 	const responsiveAssertFunctions = viewports.map( viewport => {
 		const assertDesktopOnlyFunction = generateAssertDesktopOnlyFunction( viewport )
 		if ( disableItAssertion ) {
-			return () => callback( viewport, assertDesktopOnlyFunction, registerBlockSnapshots )
+			return () => callback( viewport, assertDesktopOnlyFunction )
 		}
 		return () => {
 			it( `should adjust ${ lowerCase( viewport ) } options inside ${ lowerCase( tab ) } tab`, () => {
-				callback( viewport, assertDesktopOnlyFunction, registerBlockSnapshots )
+				callback( viewport, assertDesktopOnlyFunction )
 			} )
 		}
 	} )

--- a/cypress/support/stackable/helpers/index.js
+++ b/cypress/support/stackable/helpers/index.js
@@ -10,7 +10,7 @@ import { registerBlockSnapshots } from '~gutenberg-e2e/plugins'
  * Export Block Module assertions.
  */
 export {
-	assertBlockTitleDescription, assertBlockBackground, assertSeparators,
+	assertBlockTitleDescription, assertBlockTitleDescriptionContent, assertBlockBackground, assertSeparators,
 } from './modules'
 
 /*

--- a/cypress/support/stackable/helpers/modules.js
+++ b/cypress/support/stackable/helpers/modules.js
@@ -98,9 +98,6 @@ export const assertBlockTitleDescription = ( options = {}, assertOptions = {} ) 
  * @param {Object} assertOptions
  */
 export const assertBlockTitleDescriptionContent = ( subject, options = {}, assertOptions = {} ) => {
-	const {
-
-	} = options
 
 	const typographyAssertions = [ 'Title', 'Description' ]
 

--- a/cypress/support/stackable/helpers/modules.js
+++ b/cypress/support/stackable/helpers/modules.js
@@ -91,6 +91,30 @@ export const assertBlockTitleDescription = ( options = {}, assertOptions = {} ) 
 }
 
 /**
+ * Assertion function for typing content into Block Title and Block Description.
+ *
+ * @param {string} subject
+ * @param {Object} options
+ * @param {Object} assertOptions
+ */
+export const assertBlockTitleDescriptionContent = ( subject, options = {}, assertOptions = {} ) => {
+	const {
+
+	} = options
+
+	const typographyAssertions = [ 'Title', 'Description' ]
+
+	typographyAssertions.forEach( typographyAssertion => {
+		const typographySelector = `.ugb-block-${ lowerCase( typographyAssertion ) }`
+		cy.collapse( `Block ${ typographyAssertion }` )
+		cy.toggleStyle( `Block ${ typographyAssertion }` )
+
+		cy.typeBlock( subject, typographySelector, 'Hello World! 1234' )
+			.assertBlockContent( typographySelector, 'Hello World! 1234', assertOptions )
+	} )
+}
+
+/**
  * Assertion function for Block Background.
  *
  * @param {string} selector

--- a/cypress/support/stackable/helpers/modules.js
+++ b/cypress/support/stackable/helpers/modules.js
@@ -94,11 +94,9 @@ export const assertBlockTitleDescription = ( options = {}, assertOptions = {} ) 
  * Assertion function for typing content into Block Title and Block Description.
  *
  * @param {string} subject
- * @param {Object} options
  * @param {Object} assertOptions
  */
-export const assertBlockTitleDescriptionContent = ( subject, options = {}, assertOptions = {} ) => {
-
+export const assertBlockTitleDescriptionContent = ( subject, assertOptions = {} ) => {
 	const typographyAssertions = [ 'Title', 'Description' ]
 
 	typographyAssertions.forEach( typographyAssertion => {


### PR DESCRIPTION
Test for typing content into blocks and asserting in frontend and backend
Includes assertion for Block Title and Block Description 
Removed registerBlockSnapshots as a parameter in responsiveAssertHelper

Blocks Changed:
- Accordion
- Blockquote
- Blog Posts
- Button
- Card
- Columns
- Container
- Count Up
- Call To Action
- Divider
- Expand
- Feature Grid
- Feature
- Header
- Heading
- Icon List
- Icon
- Image Box
- Notification
- Number Box
- Pricing Box
- Separator
- Spacer
- Team Member
- Testimonial
- Text
- Video Popup